### PR TITLE
Use one_per_line if not in TTY environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - colorls -l
   - colorls README.md
   - colorls *
+  - colorls | grep /
 
 install:
   - gem install bundler

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -7,7 +7,7 @@ module ColorLS
         sort: fetch_sort_opts,
         all: flag_given?(%w[-a --all]),
         report: flag_given?(%w[-r --report]),
-        one_per_line: flag_given?(%w[-1]),
+        one_per_line: flag_given?(%w[-1]) || !STDOUT.tty?,
         long: flag_given?(%w[-l --long])
       }
 


### PR DESCRIPTION
This is related to #59 .

With normal `ls`, you get

```
$ ls
a b c
d e f
$ ls | grep a
a
```

With the current `colorls`, you get
```
$ colorls | grep a
a b c
```

because the `colorls` does not take into account the pipe environment.
This PR forces these environments to be treated differently so that the behavior is the same as normal `ls`.