### PR TITLE
dev-install: mention about installing the gem file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ Please proceed with a Pull Request only after you're assigned. It'd be sad if yo
 3. (Optional) To test whether `colorls` executable is working properly, do 
     ```sh
     rake install
+    ```
+    Then install the gem file in the folder `pkg`. After that to use the new binary,
+    ```sh
     colorls # start using colorls
     ```
 


### PR DESCRIPTION
`rake install` just creates a new gem but does not install
it and without actually installing the gem one can't test the
latest release. Thus it is essential to install it first and then
try it out.