### PR TITLE
Fix Travis CI - Rubocop error #115

### DIFF
--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'colorls/version'


### PR DESCRIPTION
Removed utf8 declaration as the default encoding for Ruby is utf8 for v2 forward. #115 