### PR TITLE
Added colorized file stats depending on size

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -209,7 +209,7 @@ module ColorLS
       size = size.colorize(@colors[:file_small])
       size = size.colorize(@colors[:file_medium]) if stat.size >= 128 * 1024 ** 2
       size = size.colorize(@colors[:file_large])  if stat.size >= 512 * 1024 ** 2
-      return size
+      size
     end
 
     def mtime_info(stat)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -206,10 +206,9 @@ module ColorLS
     def size_info(stat)
       size = Filesize.from("#{stat.size} B").pretty.split(' ')
       size = "#{size[0][0..-4].rjust(3,' ')} #{size[1].ljust(3,' ')}"
-      size = size.colorize(@colors[:file_small])
-      size = size.colorize(@colors[:file_medium]) if stat.size >= 128 * 1024 ** 2
-      size = size.colorize(@colors[:file_large])  if stat.size >= 512 * 1024 ** 2
-      size
+      return size.colorize(@colors[:file_large])  if stat.size >= 512 * 1024 ** 2
+      return size.colorize(@colors[:file_medium]) if stat.size >= 128 * 1024 ** 2
+      size.colorize(@colors[:file_small])
     end
 
     def mtime_info(stat)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -205,7 +205,11 @@ module ColorLS
 
     def size_info(stat)
       size = Filesize.from("#{stat.size} B").pretty.split(' ')
-      "#{size[0][0..-4].rjust(3,' ')} #{size[1].ljust(3,' ')}".colorize(@colors[:normal])
+      size = "#{size[0][0..-4].rjust(3,' ')} #{size[1].ljust(3,' ')}"
+      size = size.colorize(@colors[:file_small])
+      size = size.colorize(@colors[:file_medium]) if stat.size >= 128 * 1024 ** 2
+      size = size.colorize(@colors[:file_large])  if stat.size >= 512 * 1024 ** 2
+      return size
     end
 
     def mtime_info(stat)

--- a/lib/yaml/dark_colors.yaml
+++ b/lib/yaml/dark_colors.yaml
@@ -18,6 +18,11 @@ day_old:     yellow
 hour_old:    green
 no_modifier: white
 
+# File Size
+file_large:  red
+file_medium: yellow
+file_small:  green
+
 # Random
 report: white
 user:   green

--- a/lib/yaml/light_colors.yaml
+++ b/lib/yaml/light_colors.yaml
@@ -18,6 +18,11 @@ day_old:     yellow
 hour_old:    green
 no_modifier: black
 
+# File Size
+file_large:  red
+file_medium: yellow
+file_small:  green
+
 # Random
 report: black
 user:   green


### PR DESCRIPTION
Fixes #76
Size color limits are currently defined as
- 0 - 128 MB = green
- 128 - 512 MB = yellow
- 512+ MB = red

![](https://share.metamist.xyz/B1mQwxSn-)
(My green color is actually beige-ish)

Changing these hardcoded limits (as well as the harcoded limits for the date info) should probably be defined in a configuration, and possible allow users to configure as well.