### PR TITLE
Added clubbed flags and renamed multi-character shorthand arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ script:
   - ( cd spec/fixtures ; colorls .hidden-file ) | fgrep '.hidden-file'
   - colorls -l README.md
   - colorls -r
-  - colorls -sd
-  - colorls -sf
+  - colorls --sd
+  - colorls --sf
   - colorls -t
   - colorls -h
-  - colorls -gs
+  - colorls --gs
   - colorls spec/fixtures/symlinks
   - colorls README.md
   - colorls *

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -25,7 +25,7 @@ module ColorLS
     def ls
       return print "\n   Nothing to show here\n".colorize(@colors[:empty]) if @contents.empty?
 
-      return helplog if @help
+      helplog if @help
 
       if @tree
         print "\n"

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -40,7 +40,7 @@ module ColorLS
                              .map { |arg| arg[1..-1] }
 
       # Some flags should be not be able to be clubbed with other flags
-      @args.reject { |arg| arg.start_with?('--') }
+      @args.select { |arg| !arg.start_with?('--') && arg.start_with?('-') }
            .any? { |arg| clubbable_flags.any? { |flag| arg.include?(flag) } } unless unclubbable
     end
 

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -88,10 +88,12 @@ module ColorLS
     def incompatible_flags?
       return '' if @opts[:show].nil? || @opts[:sort].nil?
 
-      if @opts[:tree]
-        return 'Restrain from using -t (--tree) and -r (--report) flags together.' if @opts[:report]
-        return 'Restrain from using -t (--tree) and -l (--long) flags together.' if @opts[:long]
-        return 'Restrain from using -t (--tree) and -a (--all) flags together.' if @opts[:all]
+      [
+        ['-t (--tree)', @opts[:tree], '-r (--report)', @opts[:report]],
+        ['-t (--tree)', @opts[:tree], '-l (--long)',   @opts[:long]],
+        ['-t (--tree)', @opts[:tree], '-a (--all)',    @opts[:all]]
+      ].each do |flag1, hasflag1, flag2, hasflag2|
+        return "Restrain from using #{flag1} and #{flag2} flags together." if hasflag1 && hasflag2
       end
 
       nil

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -13,7 +13,7 @@ module ColorLS
         one_per_line: flag_given?(%w[-1]) || !STDOUT.tty?,
         long:         flag_given?(%w[-l --long]),
         tree:         flag_given?(%w[-t --tree]),
-        help:         flag_given?(%w[-h --help], true),
+        help:         flag_given?(%w[-h --help]),
         git_status:   flag_given?(%w[--gs --git-status]),
         colors: @colors
       }
@@ -33,7 +33,7 @@ module ColorLS
 
     private
 
-    def flag_given?(flags, unclubbable=false)
+    def flag_given?(flags)
       return true if flags.any? { |flag| @args.include?(flag) }
 
       clubbable_flags = flags.reject { |flag| flag.start_with?('--') }
@@ -41,7 +41,7 @@ module ColorLS
 
       # Some flags should be not be able to be clubbed with other flags
       @args.select { |arg| !arg.start_with?('--') && arg.start_with?('-') }
-           .any? { |arg| clubbable_flags.any? { |flag| arg.include?(flag) } } unless unclubbable
+           .any? { |arg| clubbable_flags.any? { |flag| arg.include?(flag) } }
     end
 
     def set_color_opts

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -37,7 +37,7 @@ module ColorLS
       return true if flags.any? { |flag| @args.include?(flag) }
 
       clubbable_flags = flags.reject { |flag| flag.start_with?('--') }
-                             .map { |arg| arg[1..-1] }
+                             .map { |flag| flag[1..-1] }
 
       # Some flags should be not be able to be clubbed with other flags
       @args.select { |arg| !arg.start_with?('--') && arg.start_with?('-') }

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -36,17 +36,14 @@ module ColorLS
     private
 
     def flag_given?(flags, unclubbable=false)
-      flags.each { |flag| return true if @args.include?(flag) }
+      return true if flags.any? { |flag| @args.include?(flag) }
+
+      clubbable_flags = flags.reject { |flag| flag.start_with?('--') }
+                             .map { |arg| arg[1..-1] }
 
       # Some flags should be not be able to be clubbed with other flags
-      unless unclubbable
-        clubbed_args = @args.select { |arg| arg.match(/^-[a-zA-Z]+$/) }.reduce(:+)
-        unless clubbed_args.nil?
-          flags.each { |flag| return true if !flag.start_with?('--') && clubbed_args.include?(flag.delete('-')) }
-        end
-      end
-
-      false
+      @args.reject { |arg| arg.start_with?('--') }
+           .any? { |arg| clubbable_flags.any? { |flag| arg.include?(flag) } } unless unclubbable
     end
 
     def set_color_opts


### PR DESCRIPTION
Fixes some notes discussed in #103
Fixes #74 

This pull request aims to move `colorls` flags closer towards `ls` attributes by allowing them to be combined together.
For example, it is now possible to use:
* `colorls -la` or `colorls -al` which is normally `colorls -l -a`
* `colorls -lr` or `colorls -rl` which is normally `colorls -l -r`
* etc.

It also renames some shorthand flags that should not be shorthand. 
What has been renamed:
* `-sd` -> `--sd`
* `-sf` -> `--sf`
* `-gs` -> `--gs`

This was done in order to not interfere with clubbed flags.

Previous functionality has not been touched, except for the renamed flags as mentioned above.