### PR TITLE
Allow specifying mutual exlusive flags

### DIFF
--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -21,13 +21,13 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'colorize'
   spec.add_runtime_dependency 'facets'
-  spec.add_runtime_dependency 'ruby-terminfo'
   spec.add_runtime_dependency 'filesize'
   spec.add_runtime_dependency 'git'
+  spec.add_runtime_dependency 'ruby-terminfo'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'diffy'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'diffy'
 end


### PR DESCRIPTION
Warning about flags that seem mutual exclusive prevents using default
flags in Shell aliases which later could be overriden.

When parsing the command line options, the last given option for a
setting (think "mode") or (light vs. dark) counts.

This is exactly how it works for `ls` and e.g. the famous curl tool.

Related to #103, in order to make colorls more compatible to `ls`.

### Description

This commit allows to specify e.g. `-r` and `-t` and `-1` flags together on the command line, without a warning, where the last flag given overrules the former ones. 

This is handy when you have aliased `colorls -la` to `la` and want to use the alias but with a different  option: `la -1`. Currently, this leads to a warning or an error.

- Relevant Issues : #103 

### Screenshots

```bash
$ colorls -atr1

     ./
     ../
     .git/
     .gitignore 
     .rubocop.yml 
     .travis.yml 
     CODE_OF_CONDUCT.md 
     CONTRIBUTING.md 
     COVERAGES.md 
     Gemfile 
     LICENSE.md 
     PULL_REQUEST_TEMPLATE.md 
     README.md 
     Rakefile 
     colorls.gemspec 
     exe/
     lib/
     readme/
     spec/
     .bundle/
     Gemfile.lock 
     .rspec_status 
     pkg/
```

### Type of change

- [x] New feature
- [ ] Bug fix for existing feature
- [ ] Code quality improvement
- [ ] Addition or Improvement of tests
- [ ] Addition or Improvement of documentation
