### PR TITLE
Use optparse for tab completion

### DIFF
--- a/lib/tab_complete.sh
+++ b/lib/tab_complete.sh
@@ -1,4 +1,4 @@
-_colorls_options='-1 -a -A -d -f -l -r -t -h
---all --almost-all --dirs --files --long --report --sort-dirs --group-directories-first
---sort-files --git-status --tree --help --sd --sf --gs'
-complete -W "${_colorls_options}" 'colorls'
+function _colorls_complete() {
+    COMPREPLY=( $( colorls --'*'-completion-bash="$2" ) )
+}
+complete -o default -F _colorls_complete colorls


### PR DESCRIPTION
### Description

This PR changes the tab completion code to use colorls itself for completing the options.

This way, the script never needs to be changed again when adding / changing command line options.

It also does normal file / directory completion when no completions were generated, so this fixes #136.

- Relevant Issues : #136 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
