### PR TITLE
Sorting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'ffi-locale', github: 'k3rni/ffi-locale'
+
 gemspec

--- a/exe/colorls
+++ b/exe/colorls
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 
 require 'colorls'
+require 'ffi-locale'
+
+# initialize locale from environment
+FFILocale.setlocale FFILocale.const_get('LC_COLLATE'), ''
+
 ColorLS::Flags.new(*ARGV).process
 true

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -3,13 +3,15 @@ require 'ffi-locale'
 module ColorLS
   class Core
     def initialize(input=nil, all: false, report: false, sort: false, show: false,
-      one_per_line: false, git_status: false,long: false, almost_all: false, tree: false, colors: [], group: nil)
+      one_per_line: false, git_status: false,long: false, almost_all: false, tree: false, colors: [], group: nil,
+      reverse: false)
       @input        = input || Dir.pwd
       @count        = {folders: 0, recognized_files: 0, unrecognized_files: 0}
       @all          = all
       @almost_all   = almost_all
       @report       = report
       @sort         = sort
+      @reverse      = reverse
       @group        = group
       @show         = show
       @one_per_line = one_per_line
@@ -106,6 +108,7 @@ module ColorLS
       else
         @contents.sort! { |a, b| FFILocale.strcoll a, b }
       end
+      @contents.reverse! if @reverse
     end
 
     def group_contents(path)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -34,7 +34,6 @@ module ColorLS
         @max_widths = @contents.transpose.map { |c| c.map(&:length).max }
         @contents.each { |chunk| ls_line(chunk) }
       end
-      print "\n"
       display_report if @report
       true
     end
@@ -276,13 +275,13 @@ module ColorLS
     end
 
     def ls_line(chunk)
-      print "\n"
       chunk.each_with_index do |content, i|
         break if content.empty?
 
         print "  #{fetch_string(@input, content, *options(@input, content))}"
         print ' ' * (@max_widths[i] - content.length) unless @one_per_line || @long
       end
+      print "\n"
     end
 
     def options(path, content)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -100,7 +100,12 @@ module ColorLS
     end
 
     def sort_contents
-      @contents.sort! { |a, b| FFILocale.strcoll a, b }
+      case @sort
+      when :time
+        @contents.sort_by! { |a| -File.mtime(a).to_f }
+      else
+        @contents.sort! { |a, b| FFILocale.strcoll a, b }
+      end
     end
 
     def group_contents(path)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -1,3 +1,5 @@
+require 'ffi-locale'
+
 module ColorLS
   class Core
     def initialize(input=nil, all: false, report: false, sort: false, show: false,
@@ -114,7 +116,7 @@ module ColorLS
     end
 
     def cmp_by_alpha(a, b)
-      a.downcase <=> b.downcase
+      FFILocale.strcoll a, b
     end
 
     def init_icons

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -101,6 +101,8 @@ module ColorLS
     end
 
     def cmp_by_dirs(path, a, b)
+      return cmp_by_alpha(a, b) if @sort == true
+
       is_a_dir = Dir.exist?("#{path}/#{a}")
       is_b_dir = Dir.exist?("#{path}/#{b}")
 

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -54,6 +54,13 @@ module ColorLS
       options.separator ''
       options.on('--sd', '--sort-dirs', '--group-directories-first', 'sort directories first') { @opts[:group] = :dirs }
       options.on('--sf', '--sort-files', 'sort files first')                                  { @opts[:group] = :files }
+      options.on('-t', 'sort by modification time, newest first')                             { @opts[:sort] = :time }
+      options.on('--sort=WORD', %w[none time], 'sort by WORD instead of name: none, time (-t)') do |word|
+        @opts[:sort] = case word
+                       when 'none' then false
+                       when 'time' then :time
+                       end
+      end
     end
 
     def add_common_options(options)

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -11,6 +11,7 @@ module ColorLS
       @opts = {
         show: false,
         sort: true,
+        group: nil,
         all: false,
         almost_all: false,
         report: false,
@@ -51,8 +52,8 @@ module ColorLS
       options.separator ''
       options.separator 'sorting options:'
       options.separator ''
-      options.on('--sd', '--sort-dirs', '--group-directories-first', 'sort directories first') { @opts[:sort] = :dirs }
-      options.on('--sf', '--sort-files', 'sort files first')                                   { @opts[:sort] = :files }
+      options.on('--sd', '--sort-dirs', '--group-directories-first', 'sort directories first') { @opts[:group] = :dirs }
+      options.on('--sf', '--sort-files', 'sort files first')                                  { @opts[:group] = :files }
     end
 
     def add_common_options(options)

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -11,6 +11,7 @@ module ColorLS
       @opts = {
         show: false,
         sort: true,
+        reverse: false,
         group: nil,
         all: false,
         almost_all: false,
@@ -61,6 +62,8 @@ module ColorLS
                        when 'time' then :time
                        end
       end
+
+      options.on('--reverse', 'reverse order while sorting') { @opts[:reverse] = true }
     end
 
     def add_common_options(options)

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -37,8 +37,10 @@ module ColorLS
 
     def process
       return Core.new(@opts).ls if @args.empty?
-      @args.each do |path|
+      @args.sort!.each_with_index do |path, i|
         next STDERR.puts "\n   Specified path '#{path}' doesn't exist.".colorize(:red) unless File.exist?(path)
+        puts '' if i > 0
+        puts "#{path}:" if Dir.exist?(path) && @args.size > 1
         Core.new(path, @opts).ls
       end
     end

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -10,7 +10,7 @@ module ColorLS
 
       @opts = {
         show: false,
-        sort: false,
+        sort: true,
         all: false,
         almost_all: false,
         report: false,

--- a/lib/colorls/version.rb
+++ b/lib/colorls/version.rb
@@ -1,3 +1,3 @@
 module ColorLS
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 end

--- a/lib/tab_complete.sh
+++ b/lib/tab_complete.sh
@@ -1,4 +1,4 @@
-_colorls_options='-1 -a -A -d -f -l -r -t -h
---all --almost-all --dirs --files --long --report --sort-dirs --group-directories-first
---sort-files --git-status --tree --help --sd --sf --gs'
-complete -W "${_colorls_options}" 'colorls'
+function _colorls_complete() {
+    COMPREPLY=( $( colorls --'*'-completion-bash="$2" ) )
+}
+complete -o default -F _colorls_complete colorls

--- a/spec/flags_spec.rb
+++ b/spec/flags_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe ColorLS::Flags do
     it { is_expected.to_not match(/├──/) } # does not display file hierarchy
   end
 
+  context 'with --reverse flag' do
+    let(:args) { ['--reverse', FIXTURES] }
+
+    it { is_expected.to match(/z-file.+symlinks.+a-file/) } # displays dirs & files in reverse alphabetical order
+  end
+
   context 'with --long flag & file path' do
     let(:args) { ['--long', "#{FIXTURES}/.hidden-file"] }
 

--- a/spec/flags_spec.rb
+++ b/spec/flags_spec.rb
@@ -20,13 +20,10 @@ RSpec.describe ColorLS::Flags do
     it { is_expected.to_not match(/((r|-).*(w|-).*(x|-).*){3}/) } # does not list file info
     it { is_expected.to_not match(/\.hidden-file/) } # does not display hidden files
     it { is_expected.to_not match(/Found \d+ contents/) } # does not show a report
+    it { is_expected.to match(/a-file.+symlinks.+z-file/) } # displays dirs & files alphabetically
     it { is_expected.to_not match(/(.*\n){3}/) } # displays multiple files per line
     it { is_expected.to_not match(%r(\.{1,2}/)) } # does not display ./ or ../
     it { is_expected.to_not match(/├──/) } # does not display file hierarchy
-  end
-
-  xcontext 'with no flags' do
-    it { is_expected.to match(/a-file.+symlinks.+z-file/) } # displays dirs & files alphabetically
   end
 
   context 'with --long flag & file path' do


### PR DESCRIPTION
### Description

This PR fixes and improves a few things regarding sorting. It adds a few more options inspired by `ls`:

* `--reverse`
* `--sort=WORD`
* `-t`

Note, that `ls` uses `-r` as the short option for `--reverse`. Alas, that is already taken by `--report`... :-(

It uses the k3rni/ffi-locale module to sort file names.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
