### PR TITLE
Add flag to sort items by modification time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - colorls -r
   - colorls --sd
   - colorls --sf
+  - colorls --st
   - colorls -t
   - colorls -h
   - colorls --gs

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -115,15 +115,19 @@ module ColorLS
       is_a_dir = Dir.exist?("#{path}/#{a}")
       is_b_dir = Dir.exist?("#{path}/#{b}")
 
-      return cmp_by_alpha(a, b) unless is_a_dir ^ is_b_dir
+      return cmp_by_alpha(a, b, path) unless is_a_dir ^ is_b_dir
 
       result = is_a_dir ? -1 : 1
       result *= -1 if @sort == :files
       result
     end
 
-    def cmp_by_alpha(a, b)
-      a.downcase <=> b.downcase
+    def cmp_by_alpha(a, b, path)
+      if @sort == :time
+        File.mtime("#{path}/#{b}") <=> File.mtime("#{path}/#{a}")
+      else
+        a.downcase <=> b.downcase
+      end
     end
 
     def init_icons

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -51,6 +51,7 @@ module ColorLS
       options.separator ''
       options.on('--sd', '--sort-dirs', '--group-directories-first', 'sort directories first') { @opts[:sort] = :dirs }
       options.on('--sf', '--sort-files', 'sort files first')                                   { @opts[:sort] = :files }
+      options.on('--st', '--sort-time', 'sort by modification time')                           { @opts[:sort] = :time }
     end
 
     def add_common_options(options)

--- a/spec/flags_spec.rb
+++ b/spec/flags_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
+require 'fileutils'
 
 RSpec.describe ColorLS::Flags do
   FIXTURES = 'spec/fixtures'.freeze
+
+  FileUtils.touch FIXTURES + '/a-file',   mtime: Time.now - 30
+  FileUtils.touch FIXTURES + '/z-file',   mtime: Time.now - 20
+  FileUtils.touch FIXTURES + '/symlinks', mtime: Time.now - 10
 
   subject { capture_stdout { ColorLS::Flags.new(*args).process } }
 
@@ -57,6 +62,12 @@ RSpec.describe ColorLS::Flags do
     let(:args) { ['--sort-files', FIXTURES] }
 
     it { is_expected.to match(/a-file.+z-file.+symlinks/) } # sorts results alphabetically, files first
+  end
+
+  context 'with --sort-time flag' do
+    let(:args) { ['--sort-time', FIXTURES] }
+
+    it { is_expected.to match(/symlinks.+z-file.+a-file/) } # sorts results by date, newest modified first
   end
 
   context 'with --dirs flag' do


### PR DESCRIPTION
This uses `File.mtime` to sort files by modification time, with the new flags `--st` and `--sort-time`.

- Relevant Issues : #151 
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
