### PR TITLE
Include Zsh completion file in the gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,4 +37,9 @@ OPTION
   IO.write('man/colorls.1', doc.convert('roff'))
 end
 
+desc 'Build the Zsh completion file'
+file 'zsh/_colorls' => ['lib/colorls/flags.rb'] do
+  ruby "exe/colorls '--*-completion-zsh=colorls' > zsh/_colorls"
+end
+
 task default: %w[spec rubocop]

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -34,8 +34,9 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features|man)/})
+    f.match(%r{^(test|spec|features)/})
   end
+
   spec.bindir        = 'exe'
   spec.executables   = 'colorls'
   spec.require_paths = ['lib']

--- a/lib/tab_complete.sh
+++ b/lib/tab_complete.sh
@@ -1,4 +1,9 @@
-function _colorls_complete() {
-    COMPREPLY=( $( colorls --'*'-completion-bash="$2" ) )
-}
-complete -o default -F _colorls_complete colorls
+
+if [ -z "${ZSH_VERSION+x}" ]; then
+    function _colorls_complete() {
+        COMPREPLY=( $( colorls --'*'-completion-bash="$2" ) )
+    }
+    complete -o default -F _colorls_complete colorls
+else
+    fpath=("${0:A:h:h}/zsh" $fpath)
+fi

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -1,0 +1,38 @@
+#compdef colorls
+
+typeset -A opt_args
+local context state line
+
+_arguments -s -S \
+  "-a[do not ignore entries starting with .]" \
+  "--all[do not ignore entries starting with .]" \
+  "-A[do not list . and ..]" \
+  "--almost-all[do not list . and ..]" \
+  "-l[use a long listing format]" \
+  "--long[use a long listing format]" \
+  "--tree[shows tree view of the directory]" \
+  "--report[show brief report]" \
+  "-1[list one file per line]" \
+  "-d[show only directories]" \
+  "--dirs[show only directories]" \
+  "-f[show only files]" \
+  "--files[show only files]" \
+  "--gs[show git status for each file]" \
+  "--git-status[show git status for each file]" \
+  "--sd[sort directories first]" \
+  "--sort-dirs[sort directories first]" \
+  "--group-directories-first[sort directories first]" \
+  "--sf[sort files first]" \
+  "--sort-files[sort files first]" \
+  "-t[sort by modification time, newest first]" \
+  "-U[do not sort; list entries in directory order]" \
+  "-S[sort by file size, largest first]" \
+  "--sort[sort by WORD instead of name: none, size (-S), time (-t)]" \
+  "-r[reverse order while sorting]" \
+  "--reverse[reverse order while sorting]" \
+  "--light[use light color scheme]" \
+  "--dark[use dark color scheme]" \
+  "-h[prints this help]" \
+  "--help[prints this help]" \
+  "--version[show version]" \
+  '*:file:_files' && return 0


### PR DESCRIPTION
Add the `_colorls` completion file to the `zsh/` folder of the gem and make the
`tab_complete.sh` script work for Zsh too.

### Description

This PR makes the tab completion work for Zsh users too. The tab_complete.sh script conditionally initializes the completion for Bash or Zsh.

- Relevant Issues : #149 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
