### PR TITLE
Proper sorting according to current LANG / locale

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ file 'man/colorls.1' => ['man/colorls.1.ronn', 'lib/colorls/flags.rb'] do
 
   flags = ColorLS::Flags.new
   attributes = {
-    date: Time.now,
+    date: Date.iso8601(`git log -1 --pretty=format:%aI -- man/colorls.1`),
     manual: 'colorls Manual',
     organization: "colorls #{ColorLS::VERSION}"
   }

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.post_install_message = ColorLS::POST_INSTALL_MESSAGE
 
+  spec.add_runtime_dependency 'clocale'
   spec.add_runtime_dependency 'filesize'
   spec.add_runtime_dependency 'manpages'
   spec.add_runtime_dependency 'rainbow'

--- a/exe/colorls
+++ b/exe/colorls
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'colorls'
+
 ColorLS::Flags.new(*ARGV).process
 true

--- a/lib/colorls.rb
+++ b/lib/colorls.rb
@@ -2,6 +2,7 @@ require 'yaml'
 require 'etc'
 require 'filesize'
 require 'rainbow/ext/string'
+require 'clocale'
 
 require 'colorls/core'
 require 'colorls/flags'

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -117,7 +117,7 @@ module ColorLS
       when :size
         @contents.sort_by! { |a| -File.size(File.join(path, a)) }
       else
-        @contents.sort! { |a, b| a.casecmp(b) }
+        @contents.sort_by! { |a| CLocale.strxfrm(a) }
       end
       @contents.reverse! if @reverse
     end

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -34,6 +34,9 @@ module ColorLS
     end
 
     def process
+      # initialize locale from environment
+      CLocale.setlocale(CLocale::LC_COLLATE, '')
+
       return Core.new(@opts).ls if @args.empty?
       @args.sort!.each_with_index do |path, i|
         next STDERR.puts "\n   Specified path '#{path}' doesn't exist.".colorize(:red) unless File.exist?(path)


### PR DESCRIPTION
### Description

This PR changes how the sorting is done.

Currently `casecmp` is used which causes indeterminate output for files differing only in case (you cannot say which comes first TEST or TeST).

Furthermore, since characters are only compared by their byte value, the files do not sort *naturally*, i.e. in German "ä" should be sorted after "a", not after "z".

This change uses the [`strxfrm`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/strxfrm.html) C library function to "canonicalize" the strings accordingly when sorting.

The LC_COLLATE locale category is initialized on program startup to the current environment. 

```
colorls -1
      abc.txt 
      äbc.txt 
      test.rb 
      TEST.rb 
```
```
LC_COLLATE=C colorls -1
      TEST.rb 
      abc.txt 
      test.rb 
      äbc.txt 
```

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
