### PR TITLE
Handle errors gracefully

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -1,9 +1,9 @@
 module ColorLS
   class Core
-    def initialize(input=nil, all: false, report: false, sort: false, show: false,
+    def initialize(input, all: false, report: false, sort: false, show: false,
       mode: nil, git_status: false, almost_all: false, colors: [], group: nil,
       reverse: false)
-      @input        = init_input_path(input)
+      @input        = File.absolute_path(input)
       @count        = {folders: 0, recognized_files: 0, unrecognized_files: 0}
       @all          = all
       @almost_all   = almost_all
@@ -43,17 +43,6 @@ module ColorLS
     end
 
     private
-
-    def init_input_path(input)
-      return Dir.pwd unless input
-      return input unless Dir.exist?(input)
-
-      actual = Dir.pwd
-      Dir.chdir(input)
-      input = Dir.pwd
-      Dir.chdir(actual)
-      input
-    end
 
     def init_contents(path)
       is_directory = Dir.exist?(path)

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -37,12 +37,16 @@ module ColorLS
       # initialize locale from environment
       CLocale.setlocale(CLocale::LC_COLLATE, '')
 
-      return Core.new(@opts).ls if @args.empty?
+      @args = [Dir.pwd] if @args.empty?
       @args.sort!.each_with_index do |path, i|
-        next STDERR.puts "\n   Specified path '#{path}' doesn't exist.".colorize(:red) unless File.exist?(path)
-        puts '' if i > 0
-        puts "#{path}:" if Dir.exist?(path) && @args.size > 1
-        Core.new(path, @opts).ls
+        begin
+          next STDERR.puts "\n   Specified path '#{path}' doesn't exist.".colorize(:red) unless File.exist?(path)
+          puts '' if i > 0
+          puts "\n#{path}:" if Dir.exist?(path) && @args.size > 1
+          Core.new(path, @opts).ls
+        rescue SystemCallError => e
+          STDERR.puts "#{path}: #{e}".colorize(:red)
+        end
       end
     end
 


### PR DESCRIPTION
Do not print a backtrace when an Exception occurs and keep going to process
arguments after an error.

before:
```sh
$ colorls /etc/openvpn/client
Errno::EACCES: Permission denied @ dir_chdir - /etc/openvpn/client
  /home/claudio/github/colorls/lib/colorls/core.rb:49:in `chdir'
  /home/claudio/github/colorls/lib/colorls/core.rb:49:in `init_input_path'
  /home/claudio/github/colorls/lib/colorls/core.rb:6:in `initialize'
  /home/claudio/github/colorls/lib/colorls/flags.rb:45:in `new'
  /home/claudio/github/colorls/lib/colorls/flags.rb:45:in `block in process'
  /home/claudio/github/colorls/lib/colorls/flags.rb:41:in `each'
  /home/claudio/github/colorls/lib/colorls/flags.rb:41:in `each_with_index'
  /home/claudio/github/colorls/lib/colorls/flags.rb:41:in `process'
  /home/claudio/github/colorls/exe/colorls:5:in `<top (required)>'
  /home/claudio/.local/bundle/ruby/2.4.0/bin/colorls:23:in `load'
  /home/claudio/.local/bundle/ruby/2.4.0/bin/colorls:23:in `<top (required)>'
```
after:
```sh
$ colorls /etc/openvpn/client
/etc/openvpn/client: Permission denied @ dir_chdir - /etc/openvpn/client
```

### Description

Thanks for contributing this Pull Request. Add a brief description of what this Pull Request does. Do tag the relevant issue(s) and PR(s) below. If required, add some screenshot(s) to support your changes.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
