### PR TITLE
Small improvements

### DIFF
--- a/lib/colorls.rb
+++ b/lib/colorls.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'etc'
 require 'filesize'
+require 'io/console'
 require 'rainbow/ext/string'
 require 'clocale'
 

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -69,7 +69,7 @@ module ColorLS
       sort_contents(path)   if @sort
       group_contents(path)  if @group
 
-      @total_content_length = @contents.count
+      @total_content_length = @contents.length
 
       return @contents unless @long
       init_user_lengths(path)
@@ -154,7 +154,7 @@ module ColorLS
     def chunkify
       return @contents.zip if @one_per_line || @long
 
-      chunk_size = @contents.count
+      chunk_size = @contents.size
 
       until in_line(chunk_size) || chunk_size <= 1
         chunk_size -= 1
@@ -166,7 +166,7 @@ module ColorLS
 
     def get_chunk(chunk_size)
       chunk       = @contents.each_slice(chunk_size).to_a
-      chunk[-1]  += [''] * (chunk_size - chunk.last.count)
+      chunk[-1]  += [''] * (chunk_size - chunk.last.size)
       @max_widths = chunk.transpose.map { |c| c.map(&:length).max }
       chunk
     end

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -16,7 +16,10 @@ module ColorLS
       @long         = mode == :long
       @tree         = mode == :tree
       process_git_status_details(git_status)
-      @screen_width = `tput cols`.chomp.to_i
+
+      @screen_width = IO.console.winsize[1]
+      @screen_width = 80 if @screen_width.zero?
+
       @colors       = colors
 
       @contents   = init_contents(@input)


### PR DESCRIPTION
### Description

The first commit changes the way the size of the current terminal is determined - I suppose this should also work under Windows, when the `tput` command is not available.

- Relevant Issues : #91 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
