### PR TITLE
Reduce syscalls and simplify code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - '2.2'
   - '2.3.0'
   - '2.4.0'
+  - '2.5.0'
 
 script:
   - bundle exec rubocop

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -58,3 +58,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'rubygems-tasks'
 end
+# rubocop:enable Metrics/BlockLength

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -57,5 +57,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'rubygems-tasks'
+  spec.add_development_dependency 'simplecov'
 end
 # rubocop:enable Metrics/BlockLength

--- a/lib/colorls.rb
+++ b/lib/colorls.rb
@@ -6,6 +6,7 @@ require 'rainbow/ext/string'
 require 'clocale'
 
 require 'colorls/core'
+require 'colorls/fileinfo'
 require 'colorls/flags'
 require 'colorls/yaml'
 require 'colorls/monkeys'

--- a/lib/colorls.rb
+++ b/lib/colorls.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'etc'
+require 'English'
 require 'filesize'
 require 'io/console'
 require 'rainbow/ext/string'

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -182,9 +182,9 @@ module ColorLS
       mode
     end
 
-    def user_info(user)
-      user = user.to_s.ljust(@userlength, ' ')
-      user.colorize(@colors[:user]) if user == Etc.getlogin
+    def user_info(content)
+      user = content.owner.ljust(@userlength, ' ')
+      user.colorize(@colors[:user]) if content.owned?
     end
 
     def group_info(group)
@@ -268,7 +268,7 @@ module ColorLS
 
     def long_info(content)
       return '' unless @long
-      [mode_info(content.stats), user_info(content.owner), group_info(content.group),
+      [mode_info(content.stats), user_info(content), group_info(content.group),
        size_info(content.size), mtime_info(content.mtime)].join('  ')
     end
 

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -250,7 +250,7 @@ module ColorLS
     end
 
     def git_dir_info(path)
-      ignored = @git_status.select { |file, mode| file.start_with?(path) && mode==' ' }.keys
+      ignored = @git_status.select { |file, mode| file.start_with?(path) && mode=='!!' }.keys
       present = Dir.deep_entries(path).map { |p| "#{path}/#{p}" }
       return '    ' if (present-ignored).empty?
 

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -201,8 +201,9 @@ module ColorLS
 
     def mtime_info(file_mtime)
       mtime = file_mtime.asctime
-      return mtime.colorize(@colors[:hour_old]) if Time.now - file_mtime < 60 * 60
-      return mtime.colorize(@colors[:day_old])  if Time.now - file_mtime < 24 * 60 * 60
+      now = Time.now
+      return mtime.colorize(@colors[:hour_old]) if now - file_mtime < 60 * 60
+      return mtime.colorize(@colors[:day_old])  if now - file_mtime < 24 * 60 * 60
       mtime.colorize(@colors[:no_modifier])
     end
 

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -22,7 +22,7 @@ module ColorLS
 
       @colors       = colors
 
-      @contents   = init_contents(@input)
+      @contents   = init_contents(input)
       @max_widths = @contents.map { |c| c.name.length }
       init_icons
     end

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -44,14 +44,14 @@ module ColorLS
     private
 
     def init_contents(path)
-      info = FileInfo.new(path)
+      info = FileInfo.new(path, link_info = @long)
 
       if info.directory?
         @contents = Dir.entries(path)
 
         filter_hidden_contents
 
-        @contents.map! { |e| FileInfo.info(File.join(path, e)) }
+        @contents.map! { |e| FileInfo.new(File.join(path, e), link_info = @long) }
 
         filter_contents if @show
         sort_contents   if @sort

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -220,14 +220,14 @@ module ColorLS
 
       # puts "\n\n"
 
-      Dir.chdir(@git_root_path)
       relative_path = path.remove(@git_root_path+'/')
       relative_path = relative_path==path ? '' : relative_path+'/'
       content_path  = "#{relative_path}#{content}"
-      content_type  = Dir.exist?("#{@git_root_path}/#{content_path}") ? :dir : :file
 
-      if content_type == :file then git_file_info(content_path)
-      else git_dir_info(content_path)
+      if content.directory?
+        git_dir_info(content_path)
+      else
+        git_file_info(content_path)
       end
       # puts "\n\n"
     end

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -208,17 +208,11 @@ module ColorLS
     def process_git_status_details(git_status)
       return false unless git_status
 
-      actual_path = Dir.pwd
-      Dir.chdir(@input)
-      until File.exist?('.git') # check whether the repository is git controlled
-        return false if Dir.pwd=='/'
-        Dir.chdir('..')
-      end
+      @git_root_path = IO.popen(['git', '-C', @input, 'rev-parse', '--show-toplevel'], err: :close, &:gets)
 
-      @git_root_path = Dir.pwd
-      Dir.chdir(actual_path)
+      return false unless $CHILD_STATUS.success?
 
-      @git_status = Git.status(@git_root_path)
+      @git_status = Git.status(@git_root_path.chomp!)
     end
 
     def git_info(path, content)

--- a/lib/colorls/fileinfo.rb
+++ b/lib/colorls/fileinfo.rb
@@ -6,10 +6,11 @@ module ColorLS
     attr_reader :stats
     attr_reader :name
 
-    def initialize(path)
+    def initialize(path, link_info=true)
       @name = File.basename(path)
       @stats = File.lstat(path)
-      return unless @stats.symlink?
+
+      return unless link_info && @stats.symlink?
       @dead = !File.exist?(path)
       @target = File.readlink(path)
     end
@@ -56,6 +57,7 @@ module ColorLS
       @stats.symlink?
     end
 
+    # target of a symlink (only available for symlinks)
     def link_target
       @target
     end

--- a/lib/colorls/fileinfo.rb
+++ b/lib/colorls/fileinfo.rb
@@ -1,0 +1,63 @@
+module ColorLS
+  class FileInfo
+    @@users  = {}              # rubocop:disable Style/ClassVars
+    @@groups = {}              # rubocop:disable Style/ClassVars
+
+    attr_reader :stats
+    attr_reader :name
+
+    def initialize(path)
+      @name = File.basename(path)
+      @stats = File.lstat(path)
+      return unless @stats.symlink?
+      @dead = !File.exist?(path)
+      @target = File.readlink(path)
+    end
+
+    def self.info(path)
+      FileInfo.new(path)
+    end
+
+    def dead?
+      @dead
+    end
+
+    def owner
+      return @@users[@stats.uid] if @@users.key? @stats.uid
+      @@users[@stats.uid] = Etc.getpwuid(@stats.uid).name
+    rescue ArgumentError
+      @stats.uid.to_s
+    end
+
+    def group
+      return @@groups[@stats.gid] if @@groups.key? @stats.gid
+      @@groups[@stats.gid] = Etc.getgrgid(@stats.gid).name
+    rescue ArgumentError
+      @stats.gid.to_s
+    end
+
+    def mtime
+      @stats.mtime
+    end
+
+    def size
+      @stats.size
+    end
+
+    def directory?
+      @stats.directory?
+    end
+
+    def symlink?
+      @stats.symlink?
+    end
+
+    def link_target
+      @target
+    end
+
+    def to_s
+      name
+    end
+  end
+end

--- a/lib/colorls/fileinfo.rb
+++ b/lib/colorls/fileinfo.rb
@@ -29,6 +29,10 @@ module ColorLS
       @stats.uid.to_s
     end
 
+    def owned?
+      @stats.owned?
+    end
+
     def group
       return @@groups[@stats.gid] if @@groups.key? @stats.gid
       @@groups[@stats.gid] = Etc.getgrgid(@stats.gid).name

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -114,4 +114,16 @@ RSpec.describe ColorLS::Flags do
 
     it { is_expected.to match(/├──/) } # displays file hierarchy
   end
+
+  context 'symlinked directory' do
+    let(:args) { [File.join(FIXTURES, 'symlinks', 'Supportlink')] }
+
+    it { is_expected.to match(/Supportlink/) }
+  end
+
+  context 'symlinked directory with trailing separator' do
+    let(:args) { [File.join(FIXTURES, 'symlinks', 'Supportlink', File::SEPARATOR)] }
+
+    it { is_expected.to match(/yaml_sort_checker.rb/) }
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'bundler/setup'
 require 'colorls'
 


### PR DESCRIPTION
### Description

This PR restructures the core class quite a bit, the main motivation being to reduce the syscalls and the code complexity.

Running `strace -c -S calls bundle exec colorls -l /usr/bin` on the current master was showing this:

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 27.43    0.058621           1     41690      2013 stat
 13.74    0.029374           1     27690           read
 15.61    0.033368           1     23478      3908 open
 10.88    0.023264           1     20021           close
  9.76    0.020851           1     19816           fstat
  3.58    0.007661           1     11724           alarm
  2.71    0.005784           1      7920           fcntl
  2.23    0.004761           1      7834           rt_sigaction
  4.29    0.009175           1      7816           write
  1.53    0.003271           1      4668           lstat
  2.46    0.005252           1      4331           readlink
  1.39    0.002975           1      4076       160 ioctl
  1.14    0.002442           1      3930           lseek
  2.05    0.004375           1      3909      3909 access
  0.57    0.001218           1      1318      1029 openat
  0.17    0.000358           2       160           socket
```
Where `stat` and `fstat` are surely some hot spots there.

Running the same command on an empty directory gave this:
```
strace -c -S calls bundle exec colorls -l empty

   Nothing to show here
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 48.48    0.001911           1      3589      3006 openat
 20.27    0.000799           0      2174         2 lstat
  7.61    0.000300           0       677           read
  4.79    0.000189           0       631           close
  4.13    0.000163           0       569           fstat
  2.54    0.000100           0       316       305 ioctl
  1.90    0.000075           0       239           fcntl
  1.67    0.000066           0       233           geteuid
  1.83    0.000072           0       231           getegid
  1.73    0.000068           0       230           getuid
  1.75    0.000069           0       230           getgid
  4.14    0.000328           1       219        18 stat
```
So, quite a lot syscalls are already needed just to start the ruby interpreter and execute the script via bundler.

I have identified the most syscalls being caused by File.exist?, File.mtime, File.size and Dir.exist? as well as looking up the current login plus the getpwuid / getgrgid calls.  

To reduce the calls, I have changed the code according to these actions:

* only call `lstat`once for each directory entry, store FileInfo instances into `@content`
* cache UID to user and GID to group information during the whole runtime of the script (GNU ls does this too)
* use stat information to determine whether a file is owned by the current user

After these changes, the syscalls are indeed reduced to a minimum:
```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
  8.61    0.001895           0      7818           write
 36.42    0.008016           1      6105         2 lstat
 11.35    0.002499           1      4660        22 stat
 21.08    0.004640           1      3669      3042 openat
  3.25    0.000716           1       764           read
  2.55    0.000562           1       688           close
  2.01    0.000442           1       621           fstat
  3.03    0.000667           2       424           readlink
  1.32    0.000290           1       355       344 ioctl
  0.75    0.000164           1       242           fcntl
  0.70    0.000154           1       236           geteuid
  0.64    0.000140           1       234           getegid
  0.69    0.000152           1       233           getuid
  0.70    0.000155           1       233           getgid
```

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

  