### PR TITLE
WIP: Generate fish completion file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,4 +42,24 @@ file 'zsh/_colorls' => ['lib/colorls/flags.rb'] do
   ruby "exe/colorls '--*-completion-zsh=colorls' > zsh/_colorls"
 end
 
+desc 'Build Fish completion file'
+file 'colorls.fish' => ['lib/colorls/flags.rb'] do
+  require 'colorls'
+  require 'shellwords'
+
+  flags = ColorLS::Flags.new
+  flags.options.each do |o|
+    short_and_long = o.flags.collect do |option|
+      case option
+      when /^--/ then "-l #{option[2..-1]}"
+      else "-s #{option[1..-1]}"
+      end
+    end.join(' ')
+
+    fixed_args = " -x -a #{Shellwords.escape o.args.join(' ')}" unless o.args.nil?
+
+    puts "complete -c colorls #{short_and_long} -d #{Shellwords.escape o.desc.first}#{fixed_args}"
+  end
+end
+
 task default: %w[spec rubocop]

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -59,7 +59,8 @@ module ColorLS
         flags = o.short + o.long
         next if flags.empty?
 
-        OpenStruct.new(flags: flags, desc: o.desc)
+        args = o.pattern.keys if Hash === o.pattern
+        OpenStruct.new(flags: flags, desc: o.desc, args: args)
       end
 
       result.compact


### PR DESCRIPTION
Fixes #163.

### Description

This is a work-in-progress PR, which generates a completion file for the fish shell. Currently, it generates the following output:

```
complete -c colorls -s a -l all -d do\ not\ ignore\ entries\ starting\ with\ .
complete -c colorls -s A -l almost-all -d do\ not\ list\ .\ and\ ..
complete -c colorls -s l -l long -d use\ a\ long\ listing\ format
complete -c colorls -l tree -d shows\ tree\ view\ of\ the\ directory
complete -c colorls -l report -d show\ brief\ report
complete -c colorls -s 1 -d list\ one\ file\ per\ line
complete -c colorls -s d -l dirs -d show\ only\ directories
complete -c colorls -s f -l files -d show\ only\ files
complete -c colorls -l gs -l git-status -d show\ git\ status\ for\ each\ file
complete -c colorls -l sd -l sort-dirs -l group-directories-first -d sort\ directories\ first
complete -c colorls -l sf -l sort-files -d sort\ files\ first
complete -c colorls -s t -d sort\ by\ modification\ time,\ newest\ first
complete -c colorls -s U -d do\ not\ sort\;\ list\ entries\ in\ directory\ order
complete -c colorls -s S -d sort\ by\ file\ size,\ largest\ first
complete -c colorls -l sort -d sort\ by\ WORD\ instead\ of\ name:\ none,\ size\ \(-S\),\ time\ \(-t\) -x -a none\ time\ size
complete -c colorls -s r -l reverse -d reverse\ order\ while\ sorting
complete -c colorls -l light -d use\ light\ color\ scheme
complete -c colorls -l dark -d use\ dark\ color\ scheme
complete -c colorls -s h -l help -d prints\ this\ help
complete -c colorls -l version -d show\ version
```
In the fish shell, you only need to run `source colorls.fish`.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
