### PR TITLE
add jupyter notebooks to file aliases

### DIFF
--- a/lib/yaml/file_aliases.yaml
+++ b/lib/yaml/file_aliases.yaml
@@ -35,6 +35,7 @@ rdoc:             md
 readme:           md
 gslides:          ppt
 pptx:             ppt
+ipynb:            py
 pyc:              py
 rdata:            r
 rds:              r


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Add a brief description of what this Pull Request does. Do tag the relevant issue(s) and PR(s) below. If required, add some screenshot(s) to support your changes.

- Relevant Issues : #177
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Adds recognition of Jupyter iPython notebooks' `.ipynb` extension as an alias for a python file.