### PR TITLE
Improve git-status processing

### DIFF
--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'colorls/version'
 

--- a/lib/colorls/git.rb
+++ b/lib/colorls/git.rb
@@ -3,7 +3,7 @@ module ColorLS
     def self.status(repo_path)
       @git_status = {}
 
-      IO.popen(['git', '-C', repo_path, 'status', '--porcelain', '-z', '-uall', '--ignored']) do |output|
+      IO.popen(['git', '-C', repo_path, 'status', '--porcelain', '-z', '-unormal', '--ignored']) do |output|
         output.read.split("\x0").map { |x| x.split(' ', 2) }.each do |mode, file|
           @git_status[file] = mode
         end

--- a/lib/colorls/git.rb
+++ b/lib/colorls/git.rb
@@ -14,13 +14,7 @@ module ColorLS
     end
 
     def self.colored_status_symbols(modes, colors)
-      modes =
-        case modes.length
-        when 1 then "  #{modes} "
-        when 2 then " #{modes} "
-        when 3 then "#{modes} "
-        when 4 then modes
-        end
+      modes = modes.rjust(3).ljust(4)
 
       modes
         .gsub('?', '?'.colorize(colors[:untracked]))


### PR DESCRIPTION
### Description

This PR fixes the speed issues reported with `--gs -a` flags and also fixes some bugs in determining the git status for directories.

In my colorls repository, I have changed the `core.rb` file. `git` reports the status as follows:
```sh
$ git status --porcelain --ignored
 M lib/colorls/core.rb
?? calls
?? lc.c
!! .#fish.org
!! .bundle/
!! .rspec_status
!! Gemfile.lock
!! coverage/
!! pkg/
```
Before: (colorls 1.1.0)
```sh
$ colorls --sd -a -1 --gs
     ✓    ./
     ✓    ../
          .bundle/
     ✓    coverage/
     ✓    exe/
     ✓    .git/
     ✓    lib/
     ✓    man/
          pkg/
     ✓    spec/
     ✓    zsh/
    ??    calls 
     ✓    CODE_OF_CONDUCT.md 
     ✓    colorls.gemspec 
     ✓    CONTRIBUTING.md 
     ✓    COVERAGES.md 
          .#fish.org 
     ✓    Gemfile 
          Gemfile.lock 
     ✓    .gitignore 
     ✓    ISSUE_TEMPLATE.md 
    ??    lc.c 
     ✓    LICENSE.md 
     ✓    PULL_REQUEST_TEMPLATE.md 
     ✓    Rakefile 
     ✓    README.md 
     ✓    RELEASE_POLICY.md 
          .rspec_status 
     ✓    .rubocop.yml 
     ✓    .travis.yml 
```
1. It reports the status of the parent folder to be "OK", which is not exactly true, since we never computed the git status for the parent directory at all.

2. It reports the status of the current folder to be "OK", which is not correct since it contains modified and untracked files.

3. It reports the status of the `lib` folder as "OK" which is incorrect since it contains a modified file.

4. It reports the status of the `coverage` folder as "OK", but this folder is ignored.

After:
```sh
$ bundle exec colorls --gs -a -1 --sd
          ./
          ../
          .bundle/
          coverage/
     ✓    empty/
     ✓    exe/
     ✓    .git/
     M    lib/
     ✓    man/
          pkg/
     ✓    spec/
     ✓    zsh/
     ?    calls 
     ✓    CODE_OF_CONDUCT.md 
     ✓    colorls.gemspec 
     ✓    CONTRIBUTING.md 
     ✓    COVERAGES.md 
          .#fish.org 
     ✓    Gemfile 
          Gemfile.lock 
     ✓    .gitignore 
     ✓    ISSUE_TEMPLATE.md 
     ?    lc.c 
     ✓    LICENSE.md 
     ✓    PULL_REQUEST_TEMPLATE.md 
     ✓    Rakefile 
     ✓    README.md 
     ✓    RELEASE_POLICY.md 
          .rspec_status 
     ✓    .rubocop.yml 
     ✓    .travis.yml 
```

TODO: 

* ~~check folders without changes which contain ignored files~~
* ~~correctly report the status of `.`~~

update 02-13-2018: it should work as expected now. And I could remove a lot of code, too. 😄 

After v2:

```sh
$ bundle exec colorls --gs -a -1 --sd
    M?    ./
          ../
          .bundle/
          coverage/
     ✓    empty/
     ✓    exe/
     ✓    .git/
     M    lib/
     ✓    man/
          pkg/
     ✓    spec/
     ✓    zsh/
     ?    calls 
     ✓    CODE_OF_CONDUCT.md 
     ✓    colorls.gemspec 
     ✓    CONTRIBUTING.md 
     ✓    COVERAGES.md 
          .#fish.org 
     ✓    Gemfile 
          Gemfile.lock 
     ✓    .gitignore 
     ✓    ISSUE_TEMPLATE.md 
     ?    lc.c 
     ✓    LICENSE.md 
     ✓    PULL_REQUEST_TEMPLATE.md 
     ✓    Rakefile 
     ✓    README.md 
     ✓    RELEASE_POLICY.md 
          .rspec_status 
     ✓    .rubocop.yml 
     ✓    .travis.yml 
```

@athityakumar could you have a look?

- Relevant Issues : #182 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
