### PR TITLE
Always return user info

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -181,8 +181,7 @@ module ColorLS
     end
 
     def user_info(content)
-      user = content.owner.ljust(@userlength, ' ')
-      user.colorize(@colors[:user]) if content.owned?
+      content.owner.ljust(@userlength, ' ').colorize(@colors[:user])
     end
 
     def group_info(group)


### PR DESCRIPTION
Fixes #187.

### Description

This fixes a regression were user information would not be shown in a long listing when the file is not owned by the user running colorls.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
