### PR TITLE
Fix #197: Take setuid, setgid and sticky bit into account

### DIFF
--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -44,6 +44,33 @@ RSpec.describe ColorLS::Flags do
     it { is_expected.to match(/((r|-).*(w|-).*(x|-).*){3}/) } # lists file info
   end
 
+  context 'with --long flag and special bits' do
+    let(:args) { ['--long', "#{FIXTURES}/a.txt"] }
+
+    it 'shows special permission bits' do
+      fileInfo = instance_double(
+        'FileInfo',
+        :group => "sys",
+        :mtime => Time.now,
+        :directory? => false,
+        :owner => "user",
+        :name => "a.txt",
+        :size => 128,
+        :symlink? => false,
+        :stats => OpenStruct.new(
+          mode: 0o444, # read for user, owner, other
+          setuid?: true,
+          setgid?: true,
+          sticky?: true
+        )
+      )
+
+      allow(ColorLS::FileInfo).to receive(:new).with("#{FIXTURES}/a.txt", true) { fileInfo }
+
+      is_expected.to match(/r-Sr-Sr-T  \s+  user  \s+  sys  .*  a.txt/mx)
+    end
+  end
+
   context 'with --all flag' do
     let(:args) { ['--all', FIXTURES] }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ require 'colorls'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |file| require file }
 
+# disable rainbow globally to ease checking expected output
+Rainbow.enabled = false
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
### Description

This PR changes the output of file permissions to correctly show permissions if a special bit is set.

- Relevant Issues : #197
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
