### PR TITLE
Add `--hyperlink` option, fix #194

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   - colorls -r
   - colorls --sd
   - colorls --sf
+  - colorls --hyperlink
   - colorls -t
   - colorls --sort=time
   - colorls -U

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -2,7 +2,7 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'colorls/version'
 
-ColorLS::POST_INSTALL_MESSAGE = %(
+POST_INSTALL_MESSAGE = %(
   *******************************************************************
     Changes introduced in colorls
 
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.executables   = 'colorls'
   spec.require_paths = ['lib']
 
-  spec.post_install_message = ColorLS::POST_INSTALL_MESSAGE
+  spec.post_install_message = POST_INSTALL_MESSAGE
 
   spec.add_runtime_dependency 'clocale', '~> 0'
   spec.add_runtime_dependency 'filesize', '~> 0'

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -2,11 +2,12 @@ module ColorLS
   class Core
     def initialize(input, all: false, report: false, sort: false, show: false,
       mode: nil, git_status: false, almost_all: false, colors: [], group: nil,
-      reverse: false)
+      reverse: false, hyperlink: false)
       @input        = File.absolute_path(input)
       @count        = {folders: 0, recognized_files: 0, unrecognized_files: 0}
       @all          = all
       @almost_all   = almost_all
+      @hyperlink    = hyperlink
       @report       = report
       @sort         = sort
       @reverse      = reverse
@@ -296,12 +297,14 @@ module ColorLS
       @count[increment] += 1
       value = increment == :folders ? @folders[key] : @files[key]
       logo  = value.gsub(/\\u[\da-f]{4}/i) { |m| [m[-4..-1].to_i(16)].pack('U') }
+      name = content.name
+      name = make_link(path, name) if @hyperlink
 
       [
         long_info(content),
         " #{git_info(path,content)} ",
         logo.colorize(color),
-        "  #{content.name.colorize(color)}#{slash?(content)}#{symlink_info(content)}"
+        "  #{name.colorize(color)}#{slash?(content)}#{symlink_info(content)}"
       ].join
     end
 
@@ -348,6 +351,11 @@ module ColorLS
     def tree_branch_preprint(prespace, indent, prespace_icon)
       return prespace_icon if prespace.zero?
       ' │ ' * (prespace/indent) + prespace_icon + '─' * indent
+    end
+
+    def make_link(path, name)
+      href = "file://#{path}/#{name}"
+      "\033]8;;#{href}\007#{name}\033]8;;\007"
     end
   end
 end

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -110,6 +110,7 @@ module ColorLS
       options.separator ''
       options.on('--light', 'use light color scheme') { @light_colors = true }
       options.on('--dark', 'use dark color scheme') { @light_colors = false }
+      options.on('--hyperlink') { @opts[:hyperlink] = true }
     end
 
     def show_examples

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "January 2018" "colorls 1.1.1" "colorls Manual"
+.TH "COLORLS" "1" "July 2018" "colorls 1.1.1" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons
@@ -97,6 +97,10 @@ use light color scheme
 .TP
 \fB\-\-dark\fR
 use dark color scheme
+.
+.TP
+\fB\-\-hyperlink\fR:
+
 .
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe ColorLS::Flags do
     it { is_expected.to match(/├──/) } # displays file hierarchy
   end
 
+  context 'with --hyperlink flag' do
+    let(:args) { ['--hyperlink', FIXTURES] }
+
+    href = "file://#{File.absolute_path(FIXTURES)}/a.txt"
+
+    it { is_expected.to match(href) }
+  end
+
   context 'symlinked directory' do
     let(:args) { [File.join(FIXTURES, 'symlinks', 'Supportlink')] }
 

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -33,6 +33,7 @@ _arguments -s -S \
   "--reverse[reverse order while sorting]" \
   "--light[use light color scheme]" \
   "--dark[use dark color scheme]" \
+  "--hyperlink[]" \
   "-h[prints this help]" \
   "--help[prints this help]" \
   "--version[show version]" \


### PR DESCRIPTION

### Description

This generates `file://` links using ANSI escape sequences which opens the
given file using the default application for the file type on your system.

A terminal emulator supporting hyperlinks is required, otherwise the links
will be ignored.

![shadow](https://user-images.githubusercontent.com/3471749/44288780-c1ba0d00-a271-11e8-98be-d31d5ad9e9d8.png)

- Relevant Issues : #194
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
