### PR TITLE
Fix #205: Handle optparse errors gracefully

### DIFF
--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -113,6 +113,15 @@ module ColorLS
       options.on('--hyperlink') { @opts[:hyperlink] = true }
     end
 
+    def add_help_option(opts)
+      opts.separator ''
+      opts.on_tail('-h', '--help', 'prints this help') do
+        puts @parser
+        show_examples
+        exit
+      end
+    end
+
     def show_examples
       puts <<EXAMPLES.gsub(/^  /, '')
 
@@ -146,13 +155,8 @@ EXAMPLES
         add_common_options(opts)
         add_sort_options(opts)
         add_general_options(opts)
+        add_help_option(opts)
 
-        opts.separator ''
-        opts.on_tail('-h', '--help', 'prints this help') do
-          puts @parser
-          show_examples
-          exit
-        end
         opts.on_tail('--version', 'show version') do
           puts ColorLS::VERSION
           exit
@@ -162,6 +166,9 @@ EXAMPLES
       @parser.parse!(@args)
 
       set_color_opts
+    rescue OptionParser::ParseError => e
+      warn "colorls: #{e}\nSee 'colorls --help'."
+      exit 2
     end
 
     def set_color_opts

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "July 2018" "colorls 1.1.1" "colorls Manual"
+.TH "COLORLS" "1" "August 2018" "colorls 1.1.1" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -167,4 +167,16 @@ RSpec.describe ColorLS::Flags do
 
     it { is_expected.to match(/yaml_sort_checker.rb/) }
   end
+
+  context 'when passing invalid flags' do
+    let(:args) { ['--snafu'] }
+
+    it 'should issue a warning, hint about `--help` and exit' do
+      allow(::Kernel).to receive(:warn) do |message|
+        expect(message).to match "--snafu"
+      end
+
+      expect { subject }.to raise_error(SystemExit).and output(/--help/).to_stderr
+    end
+  end
 end


### PR DESCRIPTION
### Description

Don't bail out with a stacktrace for invalid options.

before:
```
ls -2
Traceback (most recent call last):
	5: from /home/claudio/.gem/ruby/2.5.0/bin/colorls:23:in `<main>'
	4: from /home/claudio/.gem/ruby/2.5.0/bin/colorls:23:in `load'
	3: from /home/claudio/.gem/ruby/2.5.0/gems/colorls-1.1.2/exe/colorls:5:in `<top (required)>'
	2: from /home/claudio/.gem/ruby/2.5.0/gems/colorls-1.1.2/exe/colorls:5:in `new'
	1: from /home/claudio/.gem/ruby/2.5.0/gems/colorls-1.1.2/lib/colorls/flags.rb:24:in `initialize'
/home/claudio/.gem/ruby/2.5.0/gems/colorls-1.1.2/lib/colorls/flags.rb:161:in `parse_options': invalid option: -2 (OptionParser::InvalidOption)
```
after:
```
$ colorls -2
colorls: invalid option: -2
See 'colorls --help'.
```

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
