### PR TITLE
Fix alignment for file sizes

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -215,7 +215,7 @@ module ColorLS
 
     def size_info(filesize)
       size = Filesize.from("#{filesize} B").pretty.split(' ')
-      size = "#{size[0][0..-4].rjust(3,' ')} #{size[1].ljust(3,' ')}"
+      size = "#{size[0][0..-4].rjust(4,' ')} #{size[1].ljust(3,' ')}"
       return size.colorize(@colors[:file_large])  if filesize >= 512 * 1024 ** 2
       return size.colorize(@colors[:file_medium]) if filesize >= 128 * 1024 ** 2
       size.colorize(@colors[:file_small])


### PR DESCRIPTION
### Description

File size can be up to 1023 B/KiB/etc.
The simplest solution is to allow 4 characters for alignment.

Before:
```
  rw-r--r--  somebody  staff  143 KiB  Sat Oct 13 14:27:58 2018    Visual_SQL_JOINS_orig.jpg
  rw-r--r--  somebody  staff  1021 B    Sat Oct 13 14:29:01 2018    a-file
  rw-r--r--  somebody  staff    0 B    Tue Nov  7 02:02:07 2017    a.md
  rw-r--r--  somebody  staff    0 B    Tue Nov  7 02:02:03 2017    a.txt
  rwxr-xr-x  somebody  staff  170 B    Tue Nov  7 02:02:02 2017    symlinks/
  rw-r--r--  somebody  staff  447 B    Tue Nov  7 02:02:04 2017    z-file
  rw-r--r--  somebody  staff    0 B    Tue Nov  7 02:02:06 2017    z.txt
```

After:
```
  rw-r--r--  somebody  staff   143 KiB   Sat Oct 13 14:27:58 2018    Visual_SQL_JOINS_orig.jpg
  rw-r--r--  somebody  staff  1021 B     Sat Oct 13 14:29:01 2018    a-file
  rw-r--r--  somebody  staff     0 B     Tue Nov  7 02:02:07 2017    a.md
  rw-r--r--  somebody  staff     0 B     Tue Nov  7 02:02:03 2017    a.txt
  rwxr-xr-x  somebody  staff   170 B     Tue Nov  7 02:02:02 2017    symlinks/
  rw-r--r--  somebody  staff   447 B     Tue Nov  7 02:02:04 2017    z-file
  rw-r--r--  somebody  staff     0 B     Tue Nov  7 02:02:06 2017    z.txt
```

Note that the digits for the size of `a-file` is now properly aligned.

- Relevant Issues : #190 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
