### PR TITLE
Add `--color` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ script:
   - colorls README.md
   - colorls *
   - colorls | grep /
+  - colorls --color
+  - colorls --color=auto
+  - colorls --color=never
+  - colorls --color=always
 
 install:
   - gem install bundler

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -106,8 +106,15 @@ module ColorLS
     def add_general_options(options)
       options.separator ''
       options.separator 'general options:'
-
       options.separator ''
+
+      options.on(
+        '--color=[WHEN]', %w[always auto never],
+        'colorize the output: auto, always (default if omitted), never'
+      ) do |word|
+        # let Rainbow decide in "auto" mode
+        Rainbow.enabled = (word != 'never') unless word == 'auto'
+      end
       options.on('--light', 'use light color scheme') { @light_colors = true }
       options.on('--dark', 'use dark color scheme') { @light_colors = false }
       options.on('--hyperlink') { @opts[:hyperlink] = true }

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -91,6 +91,10 @@ sort by WORD instead of name: none, size (\-S), time (\-t), extension (\-X)
 reverse order while sorting
 .
 .TP
+\fB\-\-color\fR
+colorize the output: auto, always (default if omitted), never
+.
+.TP
 \fB\-\-light\fR
 use light color scheme
 .

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -31,6 +31,7 @@ _arguments -s -S \
   "--sort[sort by WORD instead of name: none, size (-S), time (-t), extension (-X)]" \
   "-r[reverse order while sorting]" \
   "--reverse[reverse order while sorting]" \
+  "--color[colorize the output: auto, always (default if omitted), never]" \
   "--light[use light color scheme]" \
   "--dark[use dark color scheme]" \
   "--hyperlink[]" \


### PR DESCRIPTION
### Description

This PR adds GNU ls compatible option `--color` which can be used to forcefully enable/disable coloring the output.

This mitigates a problem when Rainbow itself does not correctly determine that STDOUT / STDIN is a TTY.

- Relevant Issues : #223 
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
