### PR TITLE
Add `--format` and `-x` options

### DIFF
--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -94,13 +94,27 @@ module ColorLS
     def add_common_options(options)
       options.on('-a', '--all', 'do not ignore entries starting with .')  { @opts[:all] = true }
       options.on('-A', '--almost-all', 'do not list . and ..')            { @opts[:almost_all] = true }
-      options.on('-l', '--long', 'use a long listing format')             { @opts[:mode] = :long }
-      options.on('--tree', 'shows tree view of the directory')            { @opts[:mode] = :tree }
-      options.on('--report', 'show brief report')                         { @opts[:report] = true }
-      options.on('-1', 'list one file per line')                          { @opts[:mode] = :one_per_line }
       options.on('-d', '--dirs', 'show only directories')                 { @opts[:show] = :dirs }
       options.on('-f', '--files', 'show only files')                      { @opts[:show] = :files }
       options.on('--gs', '--git-status', 'show git status for each file') { @opts[:git_status] = true }
+      options.on('--report', 'show brief report')                         { @opts[:report] = true }
+    end
+
+    def add_format_options(options)
+      options.on(
+        '--format=WORD', %w[accross horizontal long single-column],
+        'use format: accross (-x), horizontal (-x), long (-l), single-column (-1)'
+      ) do |word|
+        case word
+        when 'accross', 'horizontal' then @opts[:mode] = true
+        when 'long' then @opts[:mode] = :long
+        when 'single-column' then @opts[:mode] = :one_per_line
+        end
+      end
+      options.on('-1', 'list one file per line')                          { @opts[:mode] = :one_per_line }
+      options.on('-l', '--long', 'use a long listing format')             { @opts[:mode] = :long }
+      options.on('--tree', 'shows tree view of the directory')            { @opts[:mode] = :tree }
+      options.on('-x', 'list entries by lines instead of by columns')     { @opts[:mode] = true }
     end
 
     def add_general_options(options)
@@ -160,6 +174,7 @@ EXAMPLES
         opts.separator ''
 
         add_common_options(opts)
+        add_format_options(opts)
         add_sort_options(opts)
         add_general_options(opts)
         add_help_option(opts)

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "August 2018" "colorls 1.1.1" "colorls Manual"
+.TH "COLORLS" "1" "October 2018" "colorls 1.1.1" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons
@@ -31,22 +31,6 @@ do not ignore entries starting with \.
 do not list \. and \.\.
 .
 .TP
-\fB\-l\fR, \fB\-\-long\fR
-use a long listing format
-.
-.TP
-\fB\-\-tree\fR
-shows tree view of the directory
-.
-.TP
-\fB\-\-report\fR
-show brief report
-.
-.TP
-\fB\-1\fR
-list one file per line
-.
-.TP
 \fB\-d\fR, \fB\-\-dirs\fR
 show only directories
 .
@@ -57,6 +41,30 @@ show only files
 .TP
 \fB\-\-gs\fR, \fB\-\-git\-status\fR
 show git status for each file
+.
+.TP
+\fB\-\-report\fR
+show brief report
+.
+.TP
+\fB\-\-format\fR
+use format: accross (\-x), horizontal (\-x), long (\-l), single\-column (\-1)
+.
+.TP
+\fB\-1\fR
+list one file per line
+.
+.TP
+\fB\-l\fR, \fB\-\-long\fR
+use a long listing format
+.
+.TP
+\fB\-\-tree\fR
+shows tree view of the directory
+.
+.TP
+\fB\-x\fR
+list entries by lines instead of by columns
 .
 .TP
 \fB\-\-sd\fR, \fB\-\-sort\-dirs\fR, \fB\-\-group\-directories\-first\fR

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe ColorLS::Flags do
     it { is_expected.to match(/z-file.+symlinks.+a-file/m) } # displays dirs & files in reverse alphabetical order
   end
 
+  context 'with --format flag' do
+    let(:args) { ['--format=single-column', FIXTURES] }
+
+    it { is_expected.to match(/.*a-file.*\n # on the first line
+                               (?m:.*)      # more lines...
+                               .*z-file.*\n # on the last line
+                              /x) }
+  end
+
   context 'with --long flag & file path' do
     let(:args) { ['--long', "#{FIXTURES}/.hidden-file"] }
 

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -8,17 +8,19 @@ _arguments -s -S \
   "--all[do not ignore entries starting with .]" \
   "-A[do not list . and ..]" \
   "--almost-all[do not list . and ..]" \
-  "-l[use a long listing format]" \
-  "--long[use a long listing format]" \
-  "--tree[shows tree view of the directory]" \
-  "--report[show brief report]" \
-  "-1[list one file per line]" \
   "-d[show only directories]" \
   "--dirs[show only directories]" \
   "-f[show only files]" \
   "--files[show only files]" \
   "--gs[show git status for each file]" \
   "--git-status[show git status for each file]" \
+  "--report[show brief report]" \
+  "--format[use format: accross (-x), horizontal (-x), long (-l), single-column (-1)]" \
+  "-1[list one file per line]" \
+  "-l[use a long listing format]" \
+  "--long[use a long listing format]" \
+  "--tree[shows tree view of the directory]" \
+  "-x[list entries by lines instead of by columns]" \
   "--sd[sort directories first]" \
   "--sort-dirs[sort directories first]" \
   "--group-directories-first[sort directories first]" \


### PR DESCRIPTION
Both are also supported by GNU ls, although currently not all formats are
supported.

This change lays ground for implementing column based formatting and also
supports using a pager with colorls keeping the formatting intact:

`colorls --color -x | less --tabs=4 -RFX`

### Description

- Relevant Issues : #171
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
