### PR TITLE
Add custom dir suffix colors

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -321,10 +321,14 @@ module ColorLS
     end
 
     def dir_color(content)
-      if @colors[:dir_suffixes] && content.name['_']
-        suffix = content.name.split(/[_]/).last.to_sym
-        @colors[:dir_suffixes][suffix]
-      end || @colors[:dir]
+      return @colors[:dir] unless @colors[:dir_suffixes]
+      name = content.name
+
+      suffix = @colors[:dir_suffixes].find do |suffix|
+        name.end_with? suffix[0].to_s
+      end
+
+      suffix ? @colors[:dir_suffixes][suffix.first] : @colors[:dir]
     end
 
     def options(content)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -324,11 +324,11 @@ module ColorLS
       return @colors[:dir] unless @colors[:dir_suffixes]
       name = content.name
 
-      suffix = @colors[:dir_suffixes].find do |suffix|
+      suffix_arr = @colors[:dir_suffixes].find do |suffix|
         name.end_with? suffix[0].to_s
       end
 
-      suffix ? @colors[:dir_suffixes][suffix.first] : @colors[:dir]
+      suffix_arr ? @colors[:dir_suffixes][suffix_arr.first] : @colors[:dir]
     end
 
     def options(content)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -290,13 +290,15 @@ module ColorLS
     end
 
     def slash?(content)
-      content.directory? ? '/'.colorize(@colors[:dir]) : ' '
+      content.directory? ? '/'.colorize(dir_color(content)) : ' '
     end
 
     def fetch_string(path, content, key, color, increment)
       @count[increment] += 1
       value = increment == :folders ? @folders[key] : @files[key]
+
       logo  = value.gsub(/\\u[\da-f]{4}/i) { |m| [m[-4..-1].to_i(16)].pack('U') }
+
       name = content.name
       name = make_link(path, name) if @hyperlink
 
@@ -318,10 +320,19 @@ module ColorLS
       print "\n"
     end
 
+    def dir_color(content)
+      if @colors[:dir_suffixes] && content.name['_']
+        suffix = content.name.split(/[_]/).last.to_sym
+        @colors[:dir_suffixes][suffix]
+      end || @colors[:dir]
+    end
+
     def options(content)
       if content.directory?
         key = content.name.to_sym
-        color = @colors[:dir]
+
+        color = dir_color(content)
+
         return [:folder, color, :folders] unless @all_folders.include?(key)
         key = @folder_aliases[key] unless @folder_keys.include?(key)
         return [key, color, :folders]

--- a/lib/colorls/yaml.rb
+++ b/lib/colorls/yaml.rb
@@ -5,6 +5,19 @@ module ColorLS
       @user_config_filepath = File.join(Dir.home, ".config/colorls/#{filename}")
     end
 
+    def deep_transform_key_vals_in_object(object, &block)
+      case object
+      when Hash
+        object.each_with_object({}) do |(key, value), result|
+          result[yield(key)] = deep_transform_key_vals_in_object(value, &block)
+        end
+      when Array
+        object.map { |e| deep_transform_key_vals_in_object(e, &block) }
+      else
+        yield object
+      end
+    end
+
     def load(aliase: false)
       yaml = read_file(@filepath)
       if File.exist?(@user_config_filepath)
@@ -13,7 +26,7 @@ module ColorLS
       end
 
       return yaml unless aliase
-      yaml.to_a.map! { |k, v| [k, v.to_sym] }.to_h
+      deep_transform_key_vals_in_object(yaml.to_a, &:to_sym).to_h
     end
 
     def read_file(filepath)

--- a/lib/yaml/dark_colors.yaml
+++ b/lib/yaml/dark_colors.yaml
@@ -2,6 +2,8 @@
 unrecognized_file: gold
 recognized_file:   lime
 dir:               dodgerblue
+dir_suffixes:
+  venv:            royalblue
 
 # Link
 dead_link: red

--- a/lib/yaml/dark_colors.yaml
+++ b/lib/yaml/dark_colors.yaml
@@ -3,7 +3,7 @@ unrecognized_file: gold
 recognized_file:   lime
 dir:               dodgerblue
 dir_suffixes:
-  venv:            royalblue
+  _venv:           royalblue
 
 # Link
 dead_link: red


### PR DESCRIPTION
### Description

This adds two things, one is a framework enhancement and the other is a feature request

#### Nested yaml structures

The framework enhancement is adding the ability to have nested `yaml` structure. Originally we convert all values in our yamls to symbols, but that was done at a flat depth -- keys were already symbols

This PR replaces that with a method that will convert all key/values to symbols at any depth so we can nest structure in our yamls

#### dir suffixes

This PR also adds the ability for users to specify custom dir suffixes

If a yaml has a structure that looks like
```
dir_suffixes:
  _suffix1: blue
  .suffix2: green
```
all directories ending in `_suffix1` and `.suffix2` will have the respective color

#### default

can remove
```
_venv:  royalblue
```
as a default if wanted

#### tests

are there any additional tests we want added for this change if we go with it?

#### documentation

what documentation, if any, would you like if we accept these changes?

- Relevant Issues : https://github.com/athityakumar/colorls/issues/206
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
