### PR TITLE
Add ruby 2.6 no warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
 
 script:
   - bundle exec rubocop
-  - bundle exec rspec
+  - bundle exec rake spec
   - bundle exec rake install
   - bundle binstubs colorls
   - PATH=$PWD/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
   - '2.3'
   - '2.4'
   - '2.5'
+  - '2.6'
 
 script:
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+conditions: v1
+
+if: branch = master OR tag IS present
+
 language:
   ruby
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,9 @@ require 'rubygems/tasks'
 Gem::Tasks.new
 
 require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "--warnings"
+end
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new do |task|

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -225,7 +225,9 @@ module ColorLS
     end
 
     def process_git_status_details(git_status)
-      return false unless git_status
+      @git_status = nil
+
+      return unless git_status
 
       @git_root_path = IO.popen(['git', '-C', @input, 'rev-parse', '--show-toplevel'], err: :close, &:gets)
 

--- a/lib/colorls/git.rb
+++ b/lib/colorls/git.rb
@@ -1,13 +1,13 @@
 module ColorLS
-  class Git < Core
+  module Git
     def self.status(repo_path)
-      @git_status = {}
+      git_status = {}
 
       IO.popen(['git', '-C', repo_path, 'status', '--porcelain', '-z', '-unormal', '--ignored']) do |output|
         while (status_line = output.gets "\x0")
           mode, file = status_line.chomp("\x0").split(' ', 2)
 
-          @git_status[file] = mode
+          git_status[file] = mode
 
           # skip the next \x0 separated original path for renames, issue #185
           output.gets("\x0") if mode.start_with? 'R'
@@ -15,7 +15,7 @@ module ColorLS
       end
       warn "git status failed in #{repo_path}" unless $CHILD_STATUS.success?
 
-      @git_status
+      git_status
     end
 
     def self.colored_status_symbols(modes, colors)

--- a/lib/colorls/monkeys.rb
+++ b/lib/colorls/monkeys.rb
@@ -23,7 +23,5 @@ class Hash
 end
 
 class Array
-  def sum
-    inject(:+)
-  end
+  define_method(:sum) { inject(:+) } unless instance_methods.include? :sum
 end


### PR DESCRIPTION
### Description

Ruby 2.6 has been released recently, add the new version to the build matrix.

Also, run the specs with warnings enabled and fix all the warnings reported.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
