### PR TITLE
Add the option to handle depth for the tree flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,6 @@ script:
   - colorls --color=auto
   - colorls --color=never
   - colorls --color=always
+  - colorls --tree
+  - colorls --tree=1
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ A Ruby script that colorizes the `ls` output with color and icons. Here are the 
     - `-h`   (or) `--help`
     - `-l`   (or) `--long`
     - `-r`   (or) `--report`
-    - `-t`   (or) `--tree`
+    - `--tree`
     - `--gs` (or) `--git-status`
     - `--sd` (or) `--sort-dirs` or `--group-directories-first`
     - `--sf` (or) `--sort-files`
+    - `-t`
   - [Combination of flags](#combination-of-flags)
 - [Installation](#installation)
 - [Recommended configurations](#recommended-configurations)
@@ -79,7 +80,7 @@ Man pages have been added. Checkout `man colorls`.
 
   ![image](https://user-images.githubusercontent.com/17109060/32149082-96a83fec-bd25-11e7-9081-7f77e4c90e90.png)
 
-- With `-t` (or) `--tree` : Shows tree view of the directory
+- With `--tree` : Shows tree view of the directory
 
   ![image](https://user-images.githubusercontent.com/17109060/32149051-32e596e4-bd25-11e7-93a9-5e50c8d2bb19.png)
 
@@ -94,6 +95,8 @@ Man pages have been added. Checkout `man colorls`.
 - With `--sf` (or) `--sort-files` : Shows files first, followed by directories
 
   ![image](https://user-images.githubusercontent.com/17109060/32149071-6b379de4-bd25-11e7-8764-a0c577e526a1.png)
+
+- With `-t` : Sort by modification time, newest first (NEED TO ADD IMAGE)
 
 - With color options : `--light` or `--dark` can be passed as a flag, to choose the appropriate color scheme. By default, the dark color scheme is chosen. In order to tweak any color, read [Custom configurations](#custom-configurations).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Ruby script that colorizes the `ls` output with color and icons. Here are the 
     - `-h`   (or) `--help`
     - `-l`   (or) `--long`
     - `-r`   (or) `--report`
-    - `--tree`
+    - `--tree` (or) `--tree=[DEPTH]`
     - `--gs` (or) `--git-status`
     - `--sd` (or) `--sort-dirs` or `--group-directories-first`
     - `--sf` (or) `--sort-files`
@@ -80,7 +80,7 @@ Man pages have been added. Checkout `man colorls`.
 
   ![image](https://user-images.githubusercontent.com/17109060/32149082-96a83fec-bd25-11e7-9081-7f77e4c90e90.png)
 
-- With `--tree` : Shows tree view of the directory
+- With `--tree` (or) `--tree=[DEPTH]` : Shows tree view of the directory with the specified depth (default 3)
 
   ![image](https://user-images.githubusercontent.com/17109060/32149051-32e596e4-bd25-11e7-93a9-5e50c8d2bb19.png)
 

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -357,12 +357,12 @@ module ColorLS
         print " #{fetch_string(path, content, *options(content))} \n"
         next unless content.directory?
 
-        tree_traverse("#{path}/#{content}", prespace + indent, depth + 1, indent) unless valid_depth?(depth + 1)
+        tree_traverse("#{path}/#{content}", prespace + indent, depth + 1, indent) if keep_going(depth)
       end
     end
 
-    def valid_depth?(depth)
-      !@tree[:depth].nil? && depth > @tree[:depth]
+    def keep_going(depth)
+      @tree[:depth].nil? || depth < @tree[:depth]
     end
 
     def tree_branch_preprint(prespace, indent, prespace_icon)

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -4,7 +4,7 @@ module ColorLS
   class Core
     def initialize(input, all: false, report: false, sort: false, show: false,
       mode: nil, git_status: false, almost_all: false, colors: [], group: nil,
-      reverse: false, hyperlink: false, tree_depth: 3)
+      reverse: false, hyperlink: false, tree_depth: nil)
       @input        = File.absolute_path(input)
       @count        = {folders: 0, recognized_files: 0, unrecognized_files: 0}
       @all          = all
@@ -357,9 +357,12 @@ module ColorLS
         print " #{fetch_string(path, content, *options(content))} \n"
         next unless content.directory?
 
-        depth += 1
-        tree_traverse("#{path}/#{content}", prespace + indent, depth, indent) unless depth > @tree[:depth]
+        tree_traverse("#{path}/#{content}", prespace + indent, depth + 1, indent) unless valid_depth?(depth + 1)
       end
+    end
+
+    def valid_depth?(depth)
+      !@tree[:depth].nil? && depth > @tree[:depth]
     end
 
     def tree_branch_preprint(prespace, indent, prespace_icon)

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -118,8 +118,8 @@ module ColorLS
       options.on('-1', 'list one file per line')                          { @opts[:mode] = :one_per_line }
       options.on('-l', '--long', 'use a long listing format')             { @opts[:mode] = :long }
       options.on('-x', 'list entries by lines instead of by columns')     { @opts[:mode] = true }
-      options.on('--tree=[DEPTH]', Integer, 'shows tree view of the directory (default depth 3)') do |depth|
-        @opts[:tree_depth] = depth || 3
+      options.on('--tree=[DEPTH]', Integer, 'shows tree view of the directory') do |depth|
+        @opts[:tree_depth] = depth
         @opts[:mode] = :tree
       end
     end

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -20,7 +20,8 @@ module ColorLS
         almost_all: false,
         report: false,
         git_status: false,
-        colors: []
+        colors: [],
+        tree_depth: 3
       }
 
       parse_options
@@ -116,8 +117,11 @@ module ColorLS
       end
       options.on('-1', 'list one file per line')                          { @opts[:mode] = :one_per_line }
       options.on('-l', '--long', 'use a long listing format')             { @opts[:mode] = :long }
-      options.on('--tree', 'shows tree view of the directory')            { @opts[:mode] = :tree }
       options.on('-x', 'list entries by lines instead of by columns')     { @opts[:mode] = true }
+      options.on('--tree=[DEPTH]', Integer, 'shows tree view of the directory (default depth 3)') do |depth|
+        @opts[:tree_depth] = depth || 3
+        @opts[:mode] = :tree
+      end
     end
 
     def add_general_options(options)

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "October 2018" "colorls 1.1.1" "colorls Manual"
+.TH "COLORLS" "1" "January 2019" "colorls 1.1.1" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons
@@ -64,7 +64,7 @@ list entries by lines instead of by columns
 .
 .TP
 \fB\-\-tree\fR
-shows tree view of the directory (default depth 3)
+shows tree view of the directory
 .
 .TP
 \fB\-\-sd\fR, \fB\-\-sort\-dirs\fR, \fB\-\-group\-directories\-first\fR

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -59,12 +59,12 @@ list one file per line
 use a long listing format
 .
 .TP
-\fB\-\-tree\fR
-shows tree view of the directory
-.
-.TP
 \fB\-x\fR
 list entries by lines instead of by columns
+.
+.TP
+\fB\-\-tree\fR
+shows tree view of the directory (default depth 3)
 .
 .TP
 \fB\-\-sd\fR, \fB\-\-sort\-dirs\fR, \fB\-\-group\-directories\-first\fR

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe ColorLS::Flags do
     let(:args) { ['--tree=1', FIXTURES] }
 
     it { is_expected.to match(/├──/) } # displays file hierarchy
-    it { is_expected.not_to match /ReadmeLink.md|Supportlink|doesnotexisttest.txt|third-level-file.txt/ }
+    it { is_expected.not_to match(/ReadmeLink.md|Supportlink|doesnotexisttest.txt|third-level-file.txt/) }
   end
 
   context 'with --tree=3 flag' do

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -184,6 +184,21 @@ RSpec.describe ColorLS::Flags do
     let(:args) { ['--tree', FIXTURES] }
 
     it { is_expected.to match(/├──/) } # displays file hierarchy
+    it { is_expected.to match(/third-level-file.txt/) }
+  end
+
+  context 'with --tree=1 flag' do
+    let(:args) { ['--tree=1', FIXTURES] }
+
+    it { is_expected.to match(/├──/) } # displays file hierarchy
+    it { is_expected.not_to match /ReadmeLink.md|Supportlink|doesnotexisttest.txt|third-level-file.txt/ }
+  end
+
+  context 'with --tree=3 flag' do
+    let(:args) { ['--tree=3', FIXTURES] }
+
+    it { is_expected.to match(/├──/) } # displays file hierarchy
+    it { is_expected.to match(/third-level-file.txt/) }
   end
 
   context 'with --hyperlink flag' do

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -19,8 +19,8 @@ _arguments -s -S \
   "-1[list one file per line]" \
   "-l[use a long listing format]" \
   "--long[use a long listing format]" \
-  "--tree[shows tree view of the directory]" \
   "-x[list entries by lines instead of by columns]" \
+  "--tree[shows tree view of the directory (default depth 3)]" \
   "--sd[sort directories first]" \
   "--sort-dirs[sort directories first]" \
   "--group-directories-first[sort directories first]" \

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -20,7 +20,7 @@ _arguments -s -S \
   "-l[use a long listing format]" \
   "--long[use a long listing format]" \
   "-x[list entries by lines instead of by columns]" \
-  "--tree[shows tree view of the directory (default depth 3)]" \
+  "--tree[shows tree view of the directory]" \
   "--sd[sort directories first]" \
   "--sort-dirs[sort directories first]" \
   "--group-directories-first[sort directories first]" \


### PR DESCRIPTION
### Introduction
Hi, I really like this gem, I was customising terminal and then, one day, I found myself running this in one of my personal projects with a lot of folders and I was surprised that nobody already fixed this so I wanted to improve in this part of the gem.

I'm not a full time ruby dev but I like to learn, Im open for suggestions and ideas 😃 

### Description
This pull request includes:
- Changes required to handle depth while using the tree flag
- Update the **README** to show the usage of the new option for tree
- Update the **README** to remove the usage of "**-t**" as a short version of "**--tree**" since that definition is wrong. "**--tree**" is to show the directory tree and "**-t**" is to sort by modification time.

There's some work to be done to consider this as finished since I made one assumption that I want to clarify.

I need to check the other options/flags on the **README** to avoid cases as with "**-t**"

- Relevant Issues : #168
- Relevant PRs : None
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [x] Addition or Improvement of documentation

![feature-tree-traverse-depth](https://user-images.githubusercontent.com/2871733/50699746-01c73400-1049-11e9-94b7-938308a7baf0.gif)

Note: Don't mind the missing icons on the gif. I'm learning how to use/customize that tool too 😅