### PR TITLE
Cope with bad symlinks in git repo directories

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -252,7 +252,8 @@ module ColorLS
       else
         git_file_info(relative_path)
       end
-      # puts "\n\n"
+    rescue Errno::ENOENT
+      return '    '
     end
 
     def git_file_info(path)


### PR DESCRIPTION
### Description

If you're working in a Git repo directory and you create a bad symlink, `colorls` will fall over when trying to list the directory:

```
No such file or directory @ realpath_rec
```

This is a small fix to handle that case, so that it will just display the same `[Dead link]` text as it would elsewhere.

---

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [X] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
