### PR TITLE
Improve git status handling

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -231,28 +231,17 @@ module ColorLS
 
       return unless git_status
 
-      @git_root_path = IO.popen(['git', '-C', @input, 'rev-parse', '--show-toplevel'], err: :close, &:gets)
-
-      return false unless $CHILD_STATUS.success?
-
-      @git_status = Git.status(@git_root_path.chomp!)
+      @git_status = Git.status(@input)
     end
 
-    def git_info(path, content)
+    def git_info(content)
       return '' unless @git_status
 
-      real_path = File.realdirpath(content.name, path)
-
-      return '    ' unless real_path.start_with? path
-
-      relative_path = real_path.remove(Regexp.new('^' + Regexp.escape(@git_root_path) + '/?'))
-
       if content.directory?
-        git_dir_info(relative_path)
+        git_dir_info(content.name)
       else
-        git_file_info(relative_path)
+        git_file_info(content.name)
       end
-      # puts "\n\n"
     end
 
     def git_file_info(path)
@@ -304,7 +293,7 @@ module ColorLS
 
       [
         long_info(content),
-        " #{git_info(path,content)} ",
+        " #{git_info(content)} ",
         logo.colorize(color),
         "  #{name.colorize(color)}#{slash?(content)}#{symlink_info(content)}"
       ].join

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -227,11 +227,11 @@ module ColorLS
     end
 
     def process_git_status_details(git_status)
-      @git_status = nil
-
-      return unless git_status
-
-      @git_status = Git.status(@input)
+      @git_status = case
+                    when !git_status then nil
+                    when File.directory?(@input) then Git.status(@input)
+                    else Git.status(File.dirname(@input))
+                    end
     end
 
     def git_info(content)

--- a/lib/colorls/monkeys.rb
+++ b/lib/colorls/monkeys.rb
@@ -12,6 +12,16 @@ class String
   def uniq
     split('').uniq.join
   end
+
+  unless instance_methods.include? :delete_prefix
+    define_method(:delete_prefix) do |prefix|
+      if start_with? prefix
+        slice(prefix.length..-1)
+      else
+        slice(0..length)
+      end
+    end
+  end
 end
 
 class Hash

--- a/spec/color_ls/monkey_spec.rb
+++ b/spec/color_ls/monkey_spec.rb
@@ -1,0 +1,23 @@
+
+RSpec.describe "String#delete_prefix" do
+  # back compat for Ruby < 2.5
+
+  it "returns a copy of the string, with the given prefix removed" do
+    expect('hello'.delete_prefix('hell')).to eq 'o'
+    expect('hello'.delete_prefix('hello')).to eq ''
+  end
+
+  it "returns a copy of the string, when the prefix isn't found" do
+    s = 'hello'
+    r = s.delete_prefix('hello!')
+    expect(r).not_to equal s
+    expect(r).to be == s
+    r = s.delete_prefix('ell')
+    expect(r).not_to equal s
+    expect(r).to be == s
+    r = s.delete_prefix('')
+    expect(r).not_to equal s
+    expect(r).to be == s
+  end
+
+end


### PR DESCRIPTION
### Description

Git reports the status for files relative to the repository root. For files in sub directories of a git repository we currently compute the common prefix of the git root and the current path in order to determine the relative path in regard to the repository root.

This approach has several problems:

* for symlinks, we always show the status of the link target instead of the symlink itself
* for broken symlinks, we show the up-to-date check mark
* symlinks to non-existent directories cause colorls to error out

Instead of computing the relative path to a file/directory in regard to the git repository root we can let git do it for us, only for the file/directory at hand.

- Relevant Issues : (none)
- Relevant PRs : #265 
- Type of change :
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
