### PR TITLE
Add `--human-readable` option for compatibility with GNU ls

### DIFF
--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -141,13 +141,22 @@ module ColorLS
       options.on('--hyperlink') { @opts[:hyperlink] = true }
     end
 
+    def add_compatiblity_options(options)
+      options.separator ''
+      options.separator 'options for compatiblity with ls (ignored):'
+      options.separator ''
+      options.on('-h', '--human-readable') {}
+    end
+
+    def show_help
+      puts @parser
+      show_examples
+      exit
+    end
+
     def add_help_option(opts)
       opts.separator ''
-      opts.on_tail('-h', '--help', 'prints this help') do
-        puts @parser
-        show_examples
-        exit
-      end
+      opts.on_tail('--help', 'prints this help') { show_help }
     end
 
     def show_examples
@@ -191,6 +200,9 @@ EXAMPLES
           exit
         end
       end
+
+      # show help and exit if the only argument is -h
+      show_help if !@args.empty? && @args.all? { |arg| arg == '-h' }
 
       @parser.parse!(@args)
 

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -115,7 +115,7 @@ use dark color scheme
 
 .
 .TP
-\fB\-h\fR, \fB\-\-help\fR
+\fB\-\-help\fR
 prints this help
 .
 .TP

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 RSpec.describe ColorLS::Flags do
@@ -148,6 +149,36 @@ RSpec.describe ColorLS::Flags do
 
       is_expected.to match(/symlinks.+a-file.+z-file/)
     end
+  end
+
+  context 'with --help flag' do
+    let(:args) { ['--help', FIXTURES] }
+
+    it { is_expected.to match(/show this help/) }
+  end
+
+  context 'with -h flag only' do
+    let(:args) { ['-h'] }
+
+    it { is_expected.to match(/show this help/) }
+  end
+
+  context 'with -h and additional argument' do
+    let(:args) { ['-h', FIXTURES] }
+
+    it { is_expected.to match(/a-file/) }
+  end
+
+  context 'with -h and additional options' do
+    let(:args) { ['-ht'] }
+
+    it { is_expected.not_to match(/show this help/) }
+  end
+
+  context 'with --human-readable flag' do
+    let(:args) { ['--human-readable', FIXTURES] }
+
+    it { is_expected.to match(/a-file/) }
   end
 
   context 'with --sort=extension flag' do

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -37,7 +37,6 @@ _arguments -s -S \
   "--light[use light color scheme]" \
   "--dark[use dark color scheme]" \
   "--hyperlink[]" \
-  "-h[prints this help]" \
   "--help[prints this help]" \
   "--version[show version]" \
   '*:file:_files' && return 0


### PR DESCRIPTION
### Description

I am using the [prezto](https://github.com/sorin-ionescu/prezto) configuration for Zsh. It automatically provides useful aliases for some ls commands:

```
alias l='ls -1A'
alias l.='ls -d .* --color=auto'
alias ll='ls -lh'
```

Some Linux distributions also provide similar (more) aliases for Bash by default.

I did alias `ls` to `colorls` of course. :smile: 

More often than not I find myself running `ll` to get a long listing of a directory. Alas, since `-h` means "show help and exit" for colorls I only get to see the help text.

This PR adds the `--human-readable` option for compatibility to GNU ls and also makes `-h` the short option corresponding to it (exactly like GNU ls).

Since `-h` was used to mean "show help and exit" in colorls from the beginning, this change also keeps this effect as a special case if `-h` is the only argument given to colorls.

- Relevant Issues : #103
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
