### PR TITLE
Fix specs exit coverage

### DIFF
--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -192,6 +192,7 @@ EXAMPLES
         add_common_options(opts)
         add_format_options(opts)
         add_sort_options(opts)
+        add_compatiblity_options(opts)
         add_general_options(opts)
         add_help_option(opts)
 

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "January 2019" "colorls 1.1.1" "colorls Manual"
+.TH "COLORLS" "1" "March 2019" "colorls 1.1.1" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons
@@ -97,6 +97,10 @@ sort by WORD instead of name: none, size (\-S), time (\-t), extension (\-X)
 .TP
 \fB\-r\fR, \fB\-\-reverse\fR
 reverse order while sorting
+.
+.TP
+\fB\-h\fR, \fB\-\-human\-readable\fR:
+
 .
 .TP
 \fB\-\-color\fR

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe ColorLS::Flags do
     $stdout = fake = StringIO.new
     yield
     fake.string
+  rescue SystemExit => e
+    raise "colorls exited with #{e.status}" unless e.success?
+    fake.string
   ensure
     $stdout = old
   end
@@ -154,13 +157,13 @@ RSpec.describe ColorLS::Flags do
   context 'with --help flag' do
     let(:args) { ['--help', FIXTURES] }
 
-    it { is_expected.to match(/show this help/) }
+    it { is_expected.to match(/prints this help/)  }
   end
 
   context 'with -h flag only' do
     let(:args) { ['-h'] }
 
-    it { is_expected.to match(/show this help/) }
+    it { is_expected.to match(/prints this help/) }
   end
 
   context 'with -h and additional argument' do
@@ -260,7 +263,7 @@ RSpec.describe ColorLS::Flags do
         expect(message).to match "--snafu"
       end
 
-      expect { subject }.to raise_error(SystemExit).and output(/--help/).to_stderr
+      expect { subject }.to raise_error('colorls exited with 2').and output(/--help/).to_stderr
     end
   end
 end

--- a/zsh/_colorls
+++ b/zsh/_colorls
@@ -33,6 +33,8 @@ _arguments -s -S \
   "--sort[sort by WORD instead of name: none, size (-S), time (-t), extension (-X)]" \
   "-r[reverse order while sorting]" \
   "--reverse[reverse order while sorting]" \
+  "-h[]" \
+  "--human-readable[]" \
   "--color[colorize the output: auto, always (default if omitted), never]" \
   "--light[use light color scheme]" \
   "--dark[use dark color scheme]" \


### PR DESCRIPTION
### Description

PR #269 broke running the specifictions since the first example calling `colorls --help` caused RSpec to exit with exit code `0`.

The coverage dropped significantly, but did not really show the cause.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
