### PR TITLE
Handle git status for `.` and `..` properly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,9 @@ Style/EmptyCaseCondition:
 Style/MultilineBlockChain:
   Enabled: false
 
+Style/StderrPuts:
+  Enabled: false
+
 # Current preferred metrics --------------------------------------------
 # Better values are encouraged, but not required.
 Metrics/AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   Include:
     - 'lib/**/*'

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -71,6 +71,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'rubocop', '~> 0.67.2'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.1.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.27'
   spec.add_development_dependency 'rubygems-tasks', '~> 0'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -251,15 +251,19 @@ module ColorLS
     end
 
     def git_dir_info(path)
+      return '    ' if path == '..'
+
       direct_status = @git_status.fetch("#{path}/", nil)
 
       return Git.colored_status_symbols(direct_status.uniq, @colors) unless direct_status.nil?
 
-      modes = @git_status.select { |file, mode| file.start_with?(path) && mode != '!!' }
+      prefix = path == '.' ? '' : path + '/'
+
+      modes = @git_status.select { |file, mode| file.start_with?(prefix) && mode != '!!' }.values
 
       return '  ✓ '.colorize(@colors[:unchanged]) if modes.empty?
 
-      Git.colored_status_symbols(modes.values.join.uniq, @colors)
+      Git.colored_status_symbols(modes.join.uniq, @colors)
     end
 
     def long_info(content)


### PR DESCRIPTION
### Description

This PR fixes a small regression introduced with #268 where the git status of `.` and `..` reported with `--git-status` would be wrong.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
