### PR TITLE
Update ruby supported version to > 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Man pages have been added. Checkout `man colorls`.
 
 [(Back to top)](#table-of-contents)
 
-1. Install Ruby (preferably, version > 2.1)
+1. Install Ruby (preferably, version > 2.2)
 2. Install the patched fonts of powerline nerd-font and/or font-awesome. Have a look at the [Nerd Font README](https://github.com/ryanoasis/nerd-fonts/blob/master/readme.md) for more installation instructions.
 
     *Note for `iTerm2` users - Please enable the Nerd Font at iTerm2 > Preferences > Profiles > Text > Non-ASCII font > Hack Regular Nerd Font Complete.*


### PR DESCRIPTION
### Description

Since you dropped support for 2.2, there was one place left in the README where it wasn't addressed.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [x] Addition or Improvement of documentation
