### PR TITLE
Do not exit if locale settings are broken

### DIFF
--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -37,8 +37,7 @@ module ColorLS
     end
 
     def process
-      # initialize locale from environment
-      CLocale.setlocale(CLocale::LC_COLLATE, '')
+      init_locale
 
       @args = [Dir.pwd] if @args.empty?
       @args.sort!.each_with_index do |path, i|
@@ -68,6 +67,13 @@ module ColorLS
     end
 
     private
+
+    def init_locale
+      # initialize locale from environment
+      CLocale.setlocale(CLocale::LC_COLLATE, '')
+    rescue RuntimeError => e
+      warn "WARN: #{e}, check your locale settings"
+    end
 
     def add_sort_options(options)
       options.separator ''

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "July 2019" "colorls 1.3.3" "colorls Manual"
+.TH "COLORLS" "1" "April 2020" "colorls 1.3.3" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -290,4 +290,14 @@ RSpec.describe ColorLS::Flags do
       expect { subject }.to raise_error('colorls exited with 2').and output(/--help/).to_stderr
     end
   end
+
+  context 'for invalid locale' do
+    let(:args) { [FIXTURES] }
+
+    it 'should warn but not raise an error' do
+      allow(CLocale).to receive(:setlocale).with(CLocale::LC_COLLATE, '').and_raise(RuntimeError.new("setlocale error"))
+
+      expect { subject }.to output(/setlocale error/).to_stderr.and output.to_stdout
+    end
+  end
 end


### PR DESCRIPTION
### Description

There were a few reports about colorls error-out with broken locale settings (especially on OSX).

To crash is rather extreme, if nothing bad can happen if calling `setlocale` fails. It's just sorting the filenames will happen to use the C locale rules.

Simply warning the user that something bad has happened and carry on.

- Relevant Issues : #203, #204, #335
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
