### PR TITLE
Fix encoding error for non UTF-8 locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ script:
   - colorls --color=always
   - colorls --tree
   - colorls --tree=1
+  - LC_ALL=C colorls spec/fixtures/
+  - LC_ALL=C colorls --git spec/fixtures/
 
 deploy:
   provider: rubygems

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -47,7 +47,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files         = IO.popen(
+    %w[git ls-files -z], external_encoding: Encoding::ASCII_8BIT
+  ).read.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
 

--- a/lib/colorls/fileinfo.rb
+++ b/lib/colorls/fileinfo.rb
@@ -16,11 +16,20 @@ module ColorLS
       @name = File.basename(path)
       @stats = File.lstat(path)
 
+      @show_name = nil
+
       handle_symlink(path) if link_info && @stats.symlink?
     end
 
     def self.info(path)
       FileInfo.new(path)
+    end
+
+    def show
+      return @show_name unless @show_name.nil?
+
+      @show_name = @name.encode(Encoding.find('filesystem'), Encoding.default_external,
+                                invalid: :replace, undef: :replace)
     end
 
     def dead?

--- a/lib/colorls/git.rb
+++ b/lib/colorls/git.rb
@@ -31,7 +31,11 @@ module ColorLS
     end
 
     def self.colored_status_symbols(modes, colors)
-      return '  ✓ '.colorize(colors[:unchanged]) if modes.empty?
+      if modes.empty?
+        return '  ✓ '
+               .encode(Encoding.default_external, undef: :replace, replace: '=')
+               .colorize(colors[:unchanged])
+      end
 
       modes = modes.to_a.join.uniq.rjust(3).ljust(4)
 
@@ -51,7 +55,10 @@ module ColorLS
       end
 
       def git_subdir_status(repo_path)
-        yield IO.popen(['git', '-C', repo_path, 'status', '--porcelain', '-z', '-unormal', '--ignored', '.'])
+        yield IO.popen(
+          ['git', '-C', repo_path, 'status', '--porcelain', '-z', '-unormal', '--ignored', '.'],
+          external_encoding: Encoding::ASCII_8BIT
+        )
       end
     end
   end

--- a/lib/colorls/yaml.rb
+++ b/lib/colorls/yaml.rb
@@ -20,7 +20,7 @@ module ColorLS
     end
 
     def read_file(filepath)
-      ::YAML.safe_load(File.read(filepath)).symbolize_keys
+      ::YAML.safe_load(File.read(filepath, encoding: Encoding::UTF_8)).symbolize_keys
     end
   end
 end

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe ColorLS::Flags do
         :directory? => false,
         :owner => "user",
         :name => "a.txt",
+        :show => "a.txt",
         :nlink => 1,
         :size => 128,
         :blockdev? => false,
@@ -95,6 +96,7 @@ RSpec.describe ColorLS::Flags do
         :directory? => false,
         :owner => "user",
         :name => "a.txt",
+        :show => "a.txt",
         :nlink => 5, # number of hardlinks
         :size => 128,
         :blockdev? => false,

--- a/spec/color_ls/git_spec.rb
+++ b/spec/color_ls/git_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe ColorLS::Git do
+  before(:all) do
+    `echo` # initialize $CHILD_STATUS
+    expect($CHILD_STATUS).to be_success
+  end
+
   def git_status(*entries)
     StringIO.new entries.map { |line| line + "\x0" }.join
   end


### PR DESCRIPTION
### Description

If the user misconfigures the locale and thus the wrong encoding is used to interpret file names, we might run into an encoding problem later.

Also, if the encoding is not capable of handling unicode symbols, we should not display icons and replace undefined characters with a replacement character.

- Relevant Issues : #352 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
