### PR TITLE
Workaround `Errno::ENOENT` error in rubygems

### DIFF
--- a/exe/colorls
+++ b/exe/colorls
@@ -1,7 +1,26 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# workaround https://github.com/rubygems/rubygems/issues/3087
+
+# rubocop:disable Style/GlobalVars
+$loading = true
+
+class Dir
+  @@old_pwd = singleton_method(:pwd) # rubocop:disable Style/ClassVars
+
+  def self.pwd
+    @@old_pwd.call
+  rescue Errno::ENOENT => e
+    return '/' if $loading
+
+    raise e
+  end
+end
+
 require 'colorls'
 
+$loading = false
+# rubocop:enable Style/GlobalVars
+
 ColorLS::Flags.new(*ARGV).process
-true

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -39,7 +39,7 @@ module ColorLS
     def process
       init_locale
 
-      @args = [Dir.pwd] if @args.empty?
+      @args = ['.'] if @args.empty?
       @args.sort!.each_with_index do |path, i|
         next STDERR.puts "\n   Specified path '#{path}' doesn't exist.".colorize(:red) unless File.exist?(path)
 

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "April 2020" "colorls 1.3.3" "colorls Manual"
+.TH "COLORLS" "1" "April 2020" "colorls 1.4.0" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons


### PR DESCRIPTION
### Description

When trying to `require` a gem running in an unlinked directory, an exception is
thrown because `Dir.pwd` is called (see rubygems/rubygems#3087).

Until the fix lands in an official release, we monkey patch `Dir.pwd` to return
'/' if a `Errno::ENOENT` exception is raised while loading the colorls gem.

This should work for all Unixes. On Windows, this error cannot happen since you
cannot unlink a directory which is still in use by a process.

Fixes #351.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
