### PR TITLE
Support hexstring colors in YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ You can overwrite the existing icons and colors mapping by copying the yaml file
 
 - To overwrite color mapping :
 
-  Please have a look at the [list of supported color names](https://github.com/sickill/rainbow#color-list). Let's say that you're using the dark color scheme and would like to change the color of untracked file (`??`) in the `--git-status` flag to yellow. Copy the defaut `dark_colors.yaml` and change it.
+  Please have a look at the [list of supported color names](https://github.com/sickill/rainbow#color-list). You may also use a color hex code as long as it is quoted within the YAML file and prefaced with a `#` symbol.
+
+  Let's say that you're using the dark color scheme and would like to change the color of untracked file (`??`) in the `--git-status` flag to yellow. Copy the defaut `dark_colors.yaml` and change it.
 
   ```sh
   cp $(dirname $(gem which colorls))/yaml/dark_colors.yaml ~/.config/colorls/dark_colors.yaml`
@@ -173,6 +175,12 @@ You can overwrite the existing icons and colors mapping by copying the yaml file
 
   ```
   untracked: yellow
+  ```
+
+  Or, using hex color codes:
+
+  ```
+  untracked: '#FFFF00'
   ```
 
 - To overwrite icon mapping :

--- a/lib/colorls/monkeys.rb
+++ b/lib/colorls/monkeys.rb
@@ -2,7 +2,7 @@
 
 class String
   def colorize(color)
-    self.color(color.to_sym)
+    self.color(color)
   end
 
   def remove(pattern)

--- a/lib/colorls/yaml.rb
+++ b/lib/colorls/yaml.rb
@@ -16,7 +16,7 @@ module ColorLS
 
       return yaml unless aliase
 
-      yaml.to_a.map! { |k, v| [k, v.to_sym] }.to_h
+      yaml.to_a.map! { |k, v| v.include?('#') ? [k, v] : [k, v.to_sym] }.to_h
     end
 
     def read_file(filepath)

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "April 2020" "colorls 1.4.0" "colorls Manual"
+.TH "COLORLS" "1" "May 2020" "colorls 1.4.1" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons


### PR DESCRIPTION
### Description

Adds ability to specify hex color codes in the YAML file in addition to the X11/ANSI defined values.

[Rainbow already supports this](https://github.com/sickill/rainbow/blob/master/lib/rainbow/color.rb#L23-L37), it's just a matter of how colorls passes the values to it.

- Relevant Issues : 
  * https://github.com/athityakumar/colorls/issues/364
  * https://github.com/athityakumar/colorls/issues/312
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

## Validation

```
bundle exec rubocop
Inspecting 10 files
..........

10 files inspected, no offenses detected
```
and
```
bundle exec rspec
.............................................................

Finished in 0.27414 seconds (files took 0.24786 seconds to load)
61 examples, 0 failures
... 434 / 489 LOC (88.75%) covered.
```

# Examples
### All hexstrings:

`cat ~/.config/colorls/dark_colors.yaml`: 

```yaml
# Main Colors
unrecognized_file: '#FFFFFF'
recognized_file:   '#FFFFFF'
dir:               '#FFFFFF'

# Link
dead_link: '#FFFFFF'
link:      '#FFFFFF'

# Access Modes
write:     '#FFFFFF'
read:      '#FFFFFF'
exec:      '#FFFFFF'
no_access: '#FFFFFF'

# Age
hour_old:    '#FFFFFF'
day_old:     '#FFFFFF'
no_modifier: '#FFFFFF'

# File Size
file_large:  '#FFFFFF'
file_medium: '#FFFFFF'
file_small:  '#FFFFFF'

# Random
report: '#FFFFFF'
user:   '#FFFFFF'
tree:   '#FFFFFF'
empty:  '#FFFFFF'
error:  '#FFFFFF'
normal: '#FFFFFF'

# Git
addition:     '#FFFFFF'
modification: '#FFFFFF'
deletion:     '#FFFFFF'
untracked:    '#FFFFFF'
unchanged:    '#FFFFFF'
```

![all-white](https://user-images.githubusercontent.com/9803299/83182804-e739a300-a0f4-11ea-856e-029105833e07.png)

### Mixed X11 and ANSI and hexstrings:

`cat ~/.config/colorls/dark_colors.yaml`: 

```yaml
# Main Colors
unrecognized_file: '#ff5555'
recognized_file:   '#6272a4'
dir:               '#bd93f9'

# Link
dead_link: red
link:      navyblue

# Access Modes
write:     green
read:      yellow
exec:      '#8be9fd'
no_access: '#f1fa8c'
...
```
![mix-hex-and-x11](https://user-images.githubusercontent.com/9803299/83183379-b27a1b80-a0f5-11ea-860c-033b8d4e1cbb.png)
