### PR TITLE
Fix bug: colorize and count the unrecognized files

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -313,7 +313,7 @@ module ColorLS
                   when file.blockdev? then :blockdev
                   when file.socket? then :socket
                   else
-                    (key != :file and @files.key?(key)) ? :recognized_file : :unrecognized_file
+                    key != :file && @files.key?(key) ? :recognized_file : :unrecognized_file
                   end
       @colors[color_key]
     end
@@ -330,7 +330,7 @@ module ColorLS
         key = @file_aliases[key] unless @files.key? key
         key = :file if key.nil?
         color = file_color(content, key)
-        group = (key != :file and @files.key?(key)) ? :recognized_files : :unrecognized_files
+        group = key != :file && @files.key?(key) ? :recognized_files : :unrecognized_files
       end
 
       [key, color, group]

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -313,7 +313,7 @@ module ColorLS
                   when file.blockdev? then :blockdev
                   when file.socket? then :socket
                   else
-                    @files.key?(key) ? :recognized_file : :unrecognized_file
+                    (key != :file and @files.key?(key)) ? :recognized_file : :unrecognized_file
                   end
       @colors[color_key]
     end
@@ -330,7 +330,7 @@ module ColorLS
         key = @file_aliases[key] unless @files.key? key
         key = :file if key.nil?
         color = file_color(content, key)
-        group = @files.key?(key) ? :recognized_files : :unrecognized_files
+        group = (key != :file and @files.key?(key)) ? :recognized_files : :unrecognized_files
       end
 
       [key, color, group]

--- a/man/colorls.1
+++ b/man/colorls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "COLORLS" "1" "May 2020" "colorls 1.4.2" "colorls Manual"
+.TH "COLORLS" "1" "September 2020" "colorls 1.4.2" "colorls Manual"
 .
 .SH "NAME"
 \fBcolorls\fR \- list directory contents with colors and icons


### PR DESCRIPTION
### Description

Fix the bug that cannot properly colorize and count the unrecognized files.
Give a look at the change of the color of *.gem file (a unrecognized file) and the bottom few lines in the following screenshots.

### BEFORE

![Screen Shot 2020-09-07 at 4 10 58 PM](https://user-images.githubusercontent.com/50312506/92364243-62174e80-f125-11ea-826e-41db94684b66.png)

### AFTER

![Screen Shot 2020-09-07 at 4 11 59 PM](https://user-images.githubusercontent.com/50312506/92364278-6cd1e380-f125-11ea-8489-88c6bb0aa455.png)

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
