### PR TITLE
Fix unrecognized files count and colorization

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -328,9 +328,9 @@ module ColorLS
       else
         key = content.name.split('.').last.downcase.to_sym
         key = @file_aliases[key] unless @files.key? key
-        key = :file if key.nil?
         color = file_color(content, key)
         group = @files.key?(key) ? :recognized_files : :unrecognized_files
+        key = :file if key.nil?
       end
 
       [key, color, group]

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -300,4 +300,12 @@ RSpec.describe ColorLS::Flags do
       expect { subject }.to output(/setlocale error/).to_stderr.and output.to_stdout
     end
   end
+
+  context 'with unrecognized files' do
+    let(:args) { ['--report', FIXTURES] }
+
+    it 'should show a report with unrecognized files' do
+      expect { subject }.to output(/Unrecognized files\s+: 3/).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
A *file* is assigned a generic icon / glyph in `files.yaml`, so looking up
`:file` in the corresponding hash always succeeds, but `:file` is also used as
the fallback key if a file's extension is not recognized.

First determining the color and group of a given file before falling back to
the `:file` key fixes this issue.

### Description

Thanks for contributing this Pull Request. Add a brief description of what this Pull Request does. Do tag the relevant issue(s) and PR(s) below. If required, add some screenshot(s) to support your changes.

- Relevant Issues : (none)
- Relevant PRs : Closes #391 
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
