### PR TITLE
Updated fontFamily for HyperJS users in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Man pages have been added. Checkout `man colorls`.
 
     *Note for `iTerm2` users - Please enable the Nerd Font at iTerm2 > Preferences > Profiles > Text > Non-ASCII font > Hack Regular Nerd Font Complete.*
 
-    *Note for `HyperJS` users - Please add `"Hack Regular Nerd"` Font as an option to `fontFamily` in your `~/.hyper.js` file.*
+    *Note for `HyperJS` users - Please add `"Hack Nerd Font"` Font as an option to `fontFamily` in your `~/.hyper.js` file.*
 
 3. Install the [colorls](https://rubygems.org/gems/colorls/) ruby gem with `gem install colorls`
 


### PR DESCRIPTION
The font family in #2 installation instruction for `HyperJS` users should be `"Hack Nerd Font"` not `"Hack Regular Nerd"`.

- Type of change :
  - [x] Addition or Improvement of documentation
