### PR TITLE
Take display width of characters into account

### DIFF
--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -63,6 +63,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'filesize', '~> 0'
   spec.add_runtime_dependency 'manpages', '~> 0'
   spec.add_runtime_dependency 'rainbow', '>= 2.2', '< 4.0'
+  spec.add_runtime_dependency 'unicode-display_width', '~> 1.7'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'codecov', '~> 0.1'

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -73,7 +73,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'rubocop', '~> 1.3.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.8.0'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.9.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0'
   spec.add_development_dependency 'rubygems-tasks', '~> 0'
   spec.add_development_dependency 'simplecov', '~> 0.19.0'

--- a/lib/colorls.rb
+++ b/lib/colorls.rb
@@ -7,6 +7,7 @@ require 'filesize'
 require 'io/console'
 require 'rainbow/ext/string'
 require 'clocale'
+require 'unicode/display_width'
 
 require 'colorls/core'
 require 'colorls/fileinfo'

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -79,7 +79,7 @@ module ColorLS
     CHARS_PER_ITEM = 12
 
     def item_widths
-      @contents.map { |item| item.show.size + CHARS_PER_ITEM }
+      @contents.map { |item| Unicode::DisplayWidth.of(item.show) + CHARS_PER_ITEM }
     end
 
     def init_contents(path)
@@ -314,7 +314,7 @@ module ColorLS
         entry = fetch_string(@input, content, *options(content))
         line << ' ' * padding
         line << '  ' << entry.encode(Encoding.default_external, undef: :replace)
-        padding = widths[i] - content.show.length - CHARS_PER_ITEM
+        padding = widths[i] - Unicode::DisplayWidth.of(content.show) - CHARS_PER_ITEM
       end
       print line << "\n"
     end


### PR DESCRIPTION
### Description

Special characters (such as chinese) have a bigger width in a terminal, so the alignment of columns breaks. We need to determine the display width of the characters to compute the proper padding needed for the next column.

- Relevant Issues : fixes #416
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
