### PR TITLE
Use `File.extname` to determine file extension

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -347,7 +347,7 @@ module ColorLS
         color = @colors[:dir]
         group = :folders
       else
-        key = content.name.split('.').last.downcase.to_sym
+        key = File.extname(content.name).delete_prefix('.').downcase.to_sym
         key = @file_aliases[key] unless @files.key? key
         color = file_color(content, key)
         group = @files.key?(key) ? :recognized_files : :unrecognized_files

--- a/spec/color_ls/core_spec.rb
+++ b/spec/color_ls/core_spec.rb
@@ -63,5 +63,26 @@ RSpec.describe ColorLS::Core do
 
       expect { subject.ls_dir(dir_info) }.to output(/mara/).to_stdout
     end
+
+    it 'works for `...`' do
+      file_info = instance_double(
+        'FileInfo',
+        group: 'sys',
+        mtime: Time.now,
+        directory?: false,
+        owner: 'user',
+        name: '...',
+        show: '...',
+        nlink: 1,
+        size: 128,
+        blockdev?: false,
+        chardev?: false,
+        socket?: false,
+        symlink?: false,
+        executable?: false
+      )
+
+      expect { subject.ls_files([file_info]) }.to output(/[.]{3}/).to_stdout
+    end
   end
 end


### PR DESCRIPTION
### Description

A file only consisting of dots could not be handled correctly.

- Relevant Issues : fixes #441.
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
