### PR TITLE
Add support for executable_file color

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -333,6 +333,7 @@ module ColorLS
                   when file.chardev?    then :chardev
                   when file.blockdev?   then :blockdev
                   when file.socket?     then :socket
+                  when file.executable? then :executable_file
                   when @files.key?(key) then :recognized_file
                   else                       :unrecognized_file
                   end

--- a/lib/yaml/dark_colors.yaml
+++ b/lib/yaml/dark_colors.yaml
@@ -1,6 +1,7 @@
 # Main Colors
 unrecognized_file: gold
-recognized_file:   lime
+recognized_file:   yellow
+executable_file:   lime
 dir:               dodgerblue
 
 # Link

--- a/lib/yaml/light_colors.yaml
+++ b/lib/yaml/light_colors.yaml
@@ -1,6 +1,7 @@
 # Main Colors
 unrecognized_file: darkred
 recognized_file:   darkgreen
+executable_file:   green
 dir:               navyblue
 
 # Link


### PR DESCRIPTION
### Add support for executable_file color

I find the default handling of executables (just printing them in bold) too subtle. To be able to make them stand out more, they can now be colored in a user-defined color.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [X] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
![image](https://user-images.githubusercontent.com/77961370/109732959-7614a800-7bbe-11eb-9920-6a8f8fda162f.png)
