### PR TITLE
Require rubocop 1.18.3

### DIFF
--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -4,7 +4,6 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'colorls/version'
 
-# rubocop:disable Layout/LineEndStringConcatenationIndentation
 POST_INSTALL_MESSAGE = %(
   *******************************************************************
     Changes introduced in colorls
@@ -25,7 +24,6 @@ POST_INSTALL_MESSAGE = %(
 
   *******************************************************************
 )
-# rubocop:enable Layout/LineEndStringConcatenationIndentation
 
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
@@ -78,7 +76,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ronn', '~> 0'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
-  spec.add_development_dependency 'rubocop', '~> 1.18.0'
+  spec.add_development_dependency 'rubocop', '~> 1.18.3'
   spec.add_development_dependency 'rubocop-performance', '~> 1.11.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.5'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0'


### PR DESCRIPTION
This fixes a false positive for Layout/LineEndStringConcatenationIndentation.

### Description

CI failed because with the newer rubocop, it is no longer necessary to disable the cop in the colorls.gemspec.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
