### PR TITLE
:sparkles:  add LibreOffices extensions to alias file

### DIFF
--- a/lib/yaml/file_aliases.yaml
+++ b/lib/yaml/file_aliases.yaml
@@ -11,6 +11,7 @@ editorconfig:     conf
 scss:             css
 docx:             doc
 gdoc:             doc
+odt:              doc
 dockerfile:       docker
 mobi:             ebook
 eot:              font
@@ -27,6 +28,7 @@ gif:              image
 ico:              image
 jpeg:             image
 jpg:              image
+odg:              image
 png:              image
 pxm:              image
 svg:              image
@@ -41,6 +43,7 @@ mkd:              md
 rdoc:             md
 readme:           md
 gslides:          ppt
+odp:              ppt
 pptx:             ppt
 ipynb:            py
 pyc:              py
@@ -81,6 +84,7 @@ exe:              windows
 ini:              windows
 csv:              xls
 gsheet:           xls
+ods:              xls
 xlsx:             xls
 xul:              xml
 yaml:             yml


### PR DESCRIPTION
### Description

This PR adds in the file_aliases yaml four LibreOffice extensions: `odg`, `odp`, `ods` and `odt`. What looked like that before:
![old-colorls](https://user-images.githubusercontent.com/21083018/132088205-07f2aaef-f30b-4abb-b319-e807d5c26aab.png)
now looks like this:
![new-colorls](https://user-images.githubusercontent.com/21083018/132088221-03839477-69a7-49e0-bd43-b8e7adc90e0b.png)

This PR refers to the issue https://github.com/athityakumar/colorls/issues/474.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
