### PR TITLE
Allow git status to be different for items in directories

### DIFF
--- a/lib/colorls/git.rb
+++ b/lib/colorls/git.rb
@@ -5,6 +5,9 @@ require 'set'
 
 module ColorLS
   module Git
+    EMPTY_SET = Set.new.freeze
+    private_constant :EMPTY_SET
+
     def self.status(repo_path)
       prefix, success = git_prefix(repo_path)
 
@@ -13,10 +16,11 @@ module ColorLS
       prefix_path = Pathname.new(prefix)
 
       git_status = Hash.new { |hash, key| hash[key] = Set.new }
+      git_status_default = EMPTY_SET
 
       git_subdir_status(repo_path) do |mode, file|
         if file == prefix
-          git_status.default = Set[mode].freeze
+          git_status_default = Set[mode].freeze
         else
           path = Pathname.new(file).relative_path_from(prefix_path)
           git_status[path.descend.first.cleanpath.to_s].add(mode)
@@ -25,7 +29,7 @@ module ColorLS
 
       warn "git status failed in #{repo_path}" unless $CHILD_STATUS.success?
 
-      git_status.default = Set.new.freeze if git_status.default.nil?
+      git_status.default = git_status_default
       git_status.freeze
     end
 


### PR DESCRIPTION
If a directory was reported with a concrete status by git, it was
assumed that all files below this directory would have the same status.

This is not the case were git ignore files are applied to some files
in subdirectories.

### Description

Thanks for contributing this Pull Request. Add a brief description of what this Pull Request does. Do tag the relevant issue(s) and PR(s) below. If required, add some screenshot(s) to support your changes.

- Relevant Issues : #461
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
