### PR TITLE
Add script to check colorls flags

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,3 +30,5 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
+    - name: Run checks
+      run: test/run

--- a/test/checks
+++ b/test/checks
@@ -1,0 +1,41 @@
+# -*- mode: sh -*-
+# shellcheck shell=bash
+
+OK colorls
+OK colorls -1
+OK colorls -a
+OK colorls -A
+OK colorls -d
+OK colorls -f
+OK colorls -l
+OK colorls -l spec/fixtures/symlinks
+( cd spec/fixtures || exit ; OUT '.hidden-file' colorls .hidden-file )
+OK colorls -l README.md
+OK colorls -r
+
+OK colorls --sd
+OK colorls --sf
+OK colorls --hyperlink
+OK colorls -t
+OK colorls --sort=time
+OK colorls -U
+OK colorls --sort=none
+OK colorls -S
+OK colorls --sort=size
+OK colorls -h
+OK colorls --gs
+OK colorls spec/fixtures/symlinks
+OK colorls README.md
+OK colorls ./*
+OUT / colorls
+OK colorls --color
+OK colorls --color=auto
+OK colorls --color=never
+OK colorls --color=always
+OK colorls --tree spec
+OK colorls --tree=1
+
+LC_ALL=C OK colorls spec/fixtures/
+LC_ALL=C OK colorls --git spec/fixtures/
+
+XFAIL 2 colorls does-not-exist

--- a/test/run
+++ b/test/run
@@ -1,0 +1,102 @@
+#! /usr/bin/env bash
+
+set -eEuCo pipefail
+
+declare RED=$'\033[31m'
+declare GREEN=$'\033[32m'
+declare RESET=$'\033[39m'
+
+declare -i ERRORS=0 TESTS=0
+
+function colorls() {
+  command bundle exec colorls "$@"
+}
+
+# check that the given command returns exit code 0
+#
+# SYNOPSIS: OK COMMAND [ARGS]
+#
+function OK() {
+  local ret
+
+  ((++TESTS))
+
+  if "$@"; then
+    echo "$GREEN" "OK  $RESET - $*" >&2
+  else
+    ret=$?
+
+    ((++ERRORS))
+
+    echo "$RED" "FAIL$RESET - $* (exit code: $ret, ${BASH_SOURCE[1]}:${BASH_LINENO[0]})" >&2
+  fi
+}
+
+# check that the given command returns a non-zero exit code
+#
+# SYNOPSIS: XFAIL [exit-code] COMMAND [ARGS]
+#
+function XFAIL() {
+  local expected ret
+
+  if [[ "$1" == [1-9] ]]; then
+    # expect a specific non-zero exit code
+    expected="$1"
+    shift
+  fi
+
+  ((++TESTS))
+
+  if "$@"; then
+    ((++ERRORS))
+
+    echo "$RED" "FAIL$RESET - $* (unexpected success, ${BASH_SOURCE[1]}:${BASH_LINENO[0]})" >&2
+  else
+    ret=$?
+    if [[ -v expected && $expected -ne $ret ]]; then
+      ((++ERRORS))
+
+      echo "$RED" "FAIL$RESET - $* (expected: $expected got $ret, ${BASH_SOURCE[1]}:${BASH_LINENO[0]})" >&2
+    else
+      echo "$GREEN" "OK  $RESET - $*" >&2
+    fi
+  fi
+}
+
+# check that the given command returns with exit code 0 and its stdout contains a text
+#
+# SYNOPSIS: OUT TEXT COMMAND [ARGS]
+#
+function OUT() {
+  local STR="$1" ret
+  shift
+
+  ((++TESTS))
+
+  if "$@" | grep -F "$STR"; then
+    echo "$GREEN" "OK  $RESET - $*" >&2
+  else
+    ret=${PIPESTATUS[0]}
+
+    ((++ERRORS))
+
+    if [[ $ret -ne 0 ]]; then
+      echo "$RED" "FAIL$RESET - $* (exit code: $ret, ${BASH_SOURCE[1]}:${BASH_LINENO[0]})" >&2
+    else
+      echo "$RED" "FAIL$RESET - $* ('$STR' not found in output, ${BASH_SOURCE[1]}:${BASH_LINENO[0]})" >&2
+    fi
+  fi
+}
+
+function summary() {
+  if [[ $ERRORS -gt 0 ]]; then
+    printf '\n\n %d of %d tests failed.' "$ERRORS" "$TESTS" >&2
+    exit 1
+  else
+    printf '\n\n %d tests passed.' "$TESTS" >&2
+  fi
+}
+
+trap summary EXIT
+
+source "$(dirname "${BASH_SOURCE[0]}")/checks"


### PR DESCRIPTION
### Description

Add a script to check colorls exit code and support for different flags. This replaces the inline yaml commands previously used in travis.yml which makes it also possible to run this locally, a la
```
$ tests/run >/dev/null
```

- Relevant Issues : #488
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
