### PR TITLE
Drop Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,10 +16,12 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0']
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,6 +25,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Shellcheck
+      if: matrix.os == 'ubuntu-latest'
+      run: shellcheck test/run test/checks
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'profile/*'
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 # Preferred codebase style ---------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Man pages have been added. Checkout `man colorls`.
 
 [(Back to top)](#table-of-contents)
 
-1. Install Ruby (preferably, version >= 2.5)
+1. Install Ruby (preferably, version >= 2.6)
 2. [Download](https://www.nerdfonts.com/font-downloads) and install a Nerd Font. Have a look at the [Nerd Font README](https://github.com/ryanoasis/nerd-fonts/blob/master/readme.md) for installation instructions.
 
     *Note for `iTerm2` users - Please enable the Nerd Font at iTerm2 > Preferences > Profiles > Text > Non-ASCII font > Hack Regular Nerd Font Complete.*

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/athityakumar/colorls'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.files = IO.popen(
     %w[git ls-files -z], external_encoding: Encoding::ASCII_8BIT

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -321,7 +321,7 @@ module ColorLS
     def fetch_string(content, key, color, increment)
       @count[increment] += 1
       value = increment == :folders ? @folders[key] : @files[key]
-      logo  = value.gsub(/\\u[\da-f]{4}/i) { |m| [m[-4..-1].to_i(16)].pack('U') }
+      logo  = value.gsub(/\\u[\da-f]{4}/i) { |m| [m[-4..].to_i(16)].pack('U') }
       name = content.show
       name = make_link(content) if @hyperlink
       name += content.directory? && @indicator_style != 'none' ? '/' : ' '

--- a/test/run
+++ b/test/run
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-set -eEuCo pipefail
+set -EuCo pipefail
+
+if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+  set -e
+fi
 
 declare RED=$'\033[31m'
 declare GREEN=$'\033[32m'
@@ -53,7 +57,7 @@ function XFAIL() {
     echo "$RED" "FAIL$RESET - $* (unexpected success, ${BASH_SOURCE[1]}:${BASH_LINENO[0]})" >&2
   else
     ret=$?
-    if [[ -v expected && $expected -ne $ret ]]; then
+    if [[ -n "$expected" && $expected -ne $ret ]]; then
       ((++ERRORS))
 
       echo "$RED" "FAIL$RESET - $* (expected: $expected got $ret, ${BASH_SOURCE[1]}:${BASH_LINENO[0]})" >&2

--- a/test/run
+++ b/test/run
@@ -103,4 +103,5 @@ function summary() {
 
 trap summary EXIT
 
+# shellcheck source=test/checks
 source "$(dirname "${BASH_SOURCE[0]}")/checks"


### PR DESCRIPTION
### Description

Ruby 2.5 is no longer maintained. Users should upgrade.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
