### PR TITLE
Fix offenses newly reported by rubocop-rspec

### DIFF
--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -79,7 +79,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.22.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.13.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.5'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.9.0'
   spec.add_development_dependency 'rubygems-tasks', '~> 0'
   spec.add_development_dependency 'simplecov', '~> 0.21.2'
 end

--- a/spec/color_ls/yaml_spec.rb
+++ b/spec/color_ls/yaml_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ColorLS::Yaml do
       let(:checker) { YamlSortChecker.new("#{base_directory}/#{filename}.yaml") }
 
       it 'is sorted correctly' do
-        expect(checker.sorted?(sort_type)).to eq true
+        expect(checker.sorted?(sort_type)).to be true
       end
     end
   end

--- a/spec/color_ls_spec.rb
+++ b/spec/color_ls_spec.rb
@@ -4,6 +4,6 @@ require 'spec_helper'
 
 RSpec.describe ColorLS do
   it 'has a version number' do
-    expect(ColorLS::VERSION).not_to be nil
+    expect(ColorLS::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
### Description

The pessimistic version contraint on rubocop-rspec permitted minor version
updates of the dependency, which broke the tests again since version 2.9.0
introduced / changed offenses:
```
rbbe rake rubocop:auto_correct
Running RuboCop...
Inspecting 22 files
.................CC...

Offenses:

spec/color_ls/yaml_spec.rb:20:47: C: [Corrected] RSpec/BeEq: Prefer be over eq.
        expect(checker.sorted?(sort_type)).to eq true
                                              ^^
spec/color_ls_spec.rb:7:37: C: [Corrected] RSpec/BeNil: Prefer be_nil over be(nil).
    expect(ColorLS::VERSION).not_to be nil
                                    ^^^^^^

22 files inspected, 2 offenses detected, 2 offenses corrected
```

Allow only the patch version to increase automatically to avoid this in the future.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
