### PR TITLE
Fix `--inode` check

### DIFF
--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -374,8 +374,8 @@ RSpec.describe ColorLS::Flags do
   context 'with --inode flag' do
     let(:args) { ['--inode', FIXTURES] }
 
-    it 'shows inode number' do
-      expect { subject }.to output(/\d{7,}/).to_stdout
+    it 'shows inode number before logo' do
+      expect { subject }.to output(/\d+ +[^ ]+ +a.md/).to_stdout
     end
   end
 


### PR DESCRIPTION
### Description

The test failed on CI, since the inode number was a 6-digit number.

```
Failures:

  1) ColorLS::Flags with --inode flag shows inode number
     Failure/Error: expect { subject }.to output(/\d{7,}/).to_stdout

       expected block to output /\d{7,}/ to stdout, but output "      786913     Glück \n      786914     a-file \n      786915     a.md \n      786916     a.tx...  second-level/\n      786920     symlinks/\n      786924     z-file \n      786925     z.txt \n"
       Diff:
       @@ -1,8 +1,15 @@
       -/\d{7,}/
       +      786913     Glück 
       +      786914     a-file 
       +      786915     a.md 
```
The range of inodes is roughly 2 to 2^32 (depending on the filesystem).


- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
