### PR TITLE
Fix displaying file name with --hyperlink

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -339,8 +339,7 @@ module ColorLS
       @count[increment] += 1
       value = increment == :folders ? @folders[key] : @files[key]
       logo  = value.gsub(/\\u[\da-f]{4}/i) { |m| [m[-4..].to_i(16)].pack('U') }
-      name = content.show
-      name = make_link(content) if @hyperlink
+      name = @hyperlink ? make_link(content) : content.show
       name += content.directory? && @indicator_style != 'none' ? '/' : ' '
       entry = "#{out_encode(logo)}  #{out_encode(name)}"
       entry = entry.bright if !content.directory? && content.executable?

--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -428,7 +428,7 @@ module ColorLS
 
     def make_link(content)
       uri = Addressable::URI.convert_path(File.absolute_path(content.path))
-      "\033]8;;#{uri}\007#{content.name}\033]8;;\007"
+      "\033]8;;#{uri}\007#{content.show}\033]8;;\007"
     end
   end
 end


### PR DESCRIPTION
- Use FileInfo#show for the hyperlink text
- Refactor hyperlink handling in `fetch_string`

### Description

This fixes the problem reported by issue #513 

- Relevant Issues : #513
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
