### PR TITLE
Pass a null device instead of explicitly closing stderr

### DIFF
--- a/lib/colorls/git.rb
+++ b/lib/colorls/git.rb
@@ -52,7 +52,7 @@ module ColorLS
 
       def git_prefix(repo_path)
         [
-          IO.popen(['git', '-C', repo_path, 'rev-parse', '--show-prefix'], err: :close, &:gets)&.chomp,
+          IO.popen(['git', '-C', repo_path, 'rev-parse', '--show-prefix'], err: File::NULL, &:gets)&.chomp,
           $CHILD_STATUS.success?
         ]
       rescue Errno::ENOENT

--- a/spec/color_ls/git_spec.rb
+++ b/spec/color_ls/git_spec.rb
@@ -39,4 +39,10 @@ RSpec.describe ColorLS::Git do
       expect(subject.status('/repo/')).to include('subdir' => Set['M', 'D'])
     end
   end
+
+  context 'determining the git status' do
+    it 'does not output to stderr' do
+      expect { subject.status('.') }.not_to output.to_stderr
+    end
+  end
 end


### PR DESCRIPTION
When calling git any error messages should be suppressed (e.g. if an directory
is not inside a git repository).

Closing the stderr output when calling `Popen.pipe` works fine on POSIX systems,
but on Windows this does not work and spits out a warning for every invocation:

```
warning: cannot close fd before spawn
```

Fixes #517.

### Description

Thanks for contributing this Pull Request. Add a brief description of what this Pull Request does. Do tag the relevant issue(s) and PR(s) below. If required, add some screenshot(s) to support your changes.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
