### PR TITLE
fix: 🐛 add support for files with no extension

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -381,7 +381,10 @@ module ColorLS
         color = @colors[:dir]
         group = :folders
       else
-        key = File.extname(content.name).delete_prefix('.').downcase.to_sym
+        extension = File.extname(content.name).delete_prefix(".")
+        basename = File.basename(content.name, ".*").delete_prefix(".")
+        key = extension.empty? ? basename : extension
+        key = key.downcase.to_sym
         key = @file_aliases[key] unless @files.key? key
         color = file_color(content, key)
         group = @files.key?(key) ? :recognized_files : :unrecognized_files


### PR DESCRIPTION
### Description

Updated the way the key is computed to allow for files without an extension to get icons.

- Relevant Issues : 
    + Fixes #459
    + Relates to #469 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
