### PR TITLE
When the argument is a file with path provided, show the relative path of the file

### DIFF
--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -58,7 +58,7 @@ module ColorLS
 
     def group_files_and_directories
       infos = @args.flat_map do |arg|
-        FileInfo.info(arg)
+        FileInfo.info(arg, show_filepath: true)
       rescue Errno::ENOENT
         $stderr.puts "colorls: Specified path '#{arg}' doesn't exist.".colorize(:red)
         @exit_status_code = 2

--- a/lib/colorls/version.rb
+++ b/lib/colorls/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ColorLS
-  VERSION = '1.5.1'
+  VERSION = '1.5.0'
 end

--- a/lib/colorls/version.rb
+++ b/lib/colorls/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ColorLS
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -100,7 +100,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
 
       expect { subject }.to output(/r-Sr-Sr-T  .*  a.txt/mx).to_stdout
@@ -133,7 +134,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
 
       expect { subject }.to output(/\S+\s+ 5 .*  a.txt/mx).to_stdout
@@ -427,7 +429,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
     end
 
@@ -470,7 +473,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
     end
 
@@ -513,7 +517,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
     end
 
@@ -556,7 +561,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
     end
 
@@ -613,7 +619,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
     end
 
@@ -650,7 +657,8 @@ RSpec.describe ColorLS::Flags do
         path: File.join(FIXTURES, 'a.txt'),
         parent: FIXTURES,
         name: 'a.txt',
-        link_info: true
+        link_info: true,
+        show_filepath: true
       ) { file_info }
     end
 

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -108,7 +108,6 @@ RSpec.describe ColorLS::Flags do
     let(:args) { ['--long', "#{FIXTURES}/a.txt"] }
 
     it 'shows special permission bits', :use_file_info_stub do
-
       expect { subject }.to output(/r-Sr-Sr-T  .*  a.txt/mx).to_stdout
     end
 

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -486,4 +486,12 @@ RSpec.describe ColorLS::Flags do
       expect { subject }.not_to output(/128/).to_stdout
     end
   end
+
+  context 'when argument is a file with relative path' do
+    let(:args) { ["#{FIXTURES}/a.txt"] }
+
+    it 'replicates the filepath provided in the argument' do
+      expect { subject }.to output(/#{args.first}/).to_stdout
+    end
+  end
 end

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -11,6 +11,40 @@ RSpec.describe ColorLS::Flags do
     raise "colorls exited with #{e.status}" unless e.success?
   end
 
+  let(:a_txt_file_info) do
+    instance_double(
+      ColorLS::FileInfo,
+      group: 'sys',
+      mtime: Time.now,
+      directory?: false,
+      owner: 'user',
+      name: 'a.txt',
+      show: 'a.txt',
+      nlink: 1,
+      size: 128,
+      blockdev?: false,
+      chardev?: false,
+      socket?: false,
+      symlink?: false,
+      stats: instance_double(File::Stat,
+                             mode: 0o444, # read for user, owner, other
+                             setuid?: true,
+                             setgid?: true,
+                             sticky?: true),
+      executable?: false
+    )
+  end
+
+  before(:each, :use_file_info_stub) do
+    allow(ColorLS::FileInfo).to receive(:new).with(
+      path: File.join(FIXTURES, 'a.txt'),
+      parent: FIXTURES,
+      name: 'a.txt',
+      link_info: true,
+      show_filepath: true
+    ) { a_txt_file_info }
+  end
+
   context 'with no flags' do
     let(:args) { [FIXTURES] }
 
@@ -73,70 +107,13 @@ RSpec.describe ColorLS::Flags do
   context 'with --long flag for `a.txt`' do
     let(:args) { ['--long', "#{FIXTURES}/a.txt"] }
 
-    it 'shows special permission bits' do
-      file_info = instance_double(
-        ColorLS::FileInfo,
-        group: 'sys',
-        mtime: Time.now,
-        directory?: false,
-        owner: 'user',
-        name: 'a.txt',
-        show: 'a.txt',
-        nlink: 1,
-        size: 128,
-        blockdev?: false,
-        chardev?: false,
-        socket?: false,
-        symlink?: false,
-        stats: instance_double(File::Stat,
-                               mode: 0o444, # read for user, owner, other
-                               setuid?: true,
-                               setgid?: true,
-                               sticky?: true),
-        executable?: false
-      )
-
-      allow(ColorLS::FileInfo).to receive(:new).with(
-        path: File.join(FIXTURES, 'a.txt'),
-        parent: FIXTURES,
-        name: 'a.txt',
-        link_info: true,
-        show_filepath: true
-      ) { file_info }
+    it 'shows special permission bits', :use_file_info_stub do
 
       expect { subject }.to output(/r-Sr-Sr-T  .*  a.txt/mx).to_stdout
     end
 
-    it 'shows number of hardlinks' do
-      file_info = instance_double(
-        ColorLS::FileInfo,
-        group: 'sys',
-        mtime: Time.now,
-        directory?: false,
-        owner: 'user',
-        name: 'a.txt',
-        show: 'a.txt',
-        nlink: 5, # number of hardlinks
-        size: 128,
-        blockdev?: false,
-        chardev?: false,
-        socket?: false,
-        symlink?: false,
-        stats: instance_double(File::Stat,
-                               mode: 0o444, # read for user, owner, other
-                               setuid?: true,
-                               setgid?: true,
-                               sticky?: true),
-        executable?: false
-      )
-
-      allow(ColorLS::FileInfo).to receive(:new).with(
-        path: File.join(FIXTURES, 'a.txt'),
-        parent: FIXTURES,
-        name: 'a.txt',
-        link_info: true,
-        show_filepath: true
-      ) { file_info }
+    it 'shows number of hardlinks', :use_file_info_stub do
+      allow(a_txt_file_info).to receive(:nlink).and_return 5
 
       expect { subject }.to output(/\S+\s+ 5 .*  a.txt/mx).to_stdout
     end
@@ -399,40 +376,8 @@ RSpec.describe ColorLS::Flags do
     end
   end
 
-  context 'with -o flag' do
+  context 'with -o flag', :use_file_info_stub do
     let(:args) { ['-o', "#{FIXTURES}/a.txt"] }
-
-    before do
-      file_info = instance_double(
-        ColorLS::FileInfo,
-        group: 'sys',
-        mtime: Time.now,
-        directory?: false,
-        owner: 'user',
-        name: 'a.txt',
-        show: 'a.txt',
-        nlink: 1,
-        size: 128,
-        blockdev?: false,
-        chardev?: false,
-        socket?: false,
-        symlink?: false,
-        stats: instance_double(File::Stat,
-                               mode: 0o444, # read for user, owner, other
-                               setuid?: true,
-                               setgid?: true,
-                               sticky?: true),
-        executable?: false
-      )
-
-      allow(ColorLS::FileInfo).to receive(:new).with(
-        path: File.join(FIXTURES, 'a.txt'),
-        parent: FIXTURES,
-        name: 'a.txt',
-        link_info: true,
-        show_filepath: true
-      ) { file_info }
-    end
 
     it 'lists without group info' do
       expect { subject }.not_to output(/sys/).to_stdout
@@ -443,40 +388,8 @@ RSpec.describe ColorLS::Flags do
     end
   end
 
-  context 'with -g flag' do
+  context 'with -g flag', :use_file_info_stub do
     let(:args) { ['-g', "#{FIXTURES}/a.txt"] }
-
-    before do
-      file_info = instance_double(
-        ColorLS::FileInfo,
-        group: 'sys',
-        mtime: Time.now,
-        directory?: false,
-        owner: 'user',
-        name: 'a.txt',
-        show: 'a.txt',
-        nlink: 1,
-        size: 128,
-        blockdev?: false,
-        chardev?: false,
-        socket?: false,
-        symlink?: false,
-        stats: instance_double(File::Stat,
-                               mode: 0o444, # read for user, owner, other
-                               setuid?: true,
-                               setgid?: true,
-                               sticky?: true),
-        executable?: false
-      )
-
-      allow(ColorLS::FileInfo).to receive(:new).with(
-        path: File.join(FIXTURES, 'a.txt'),
-        parent: FIXTURES,
-        name: 'a.txt',
-        link_info: true,
-        show_filepath: true
-      ) { file_info }
-    end
 
     it 'lists with group info' do
       expect { subject }.to output(/sys/).to_stdout
@@ -487,40 +400,8 @@ RSpec.describe ColorLS::Flags do
     end
   end
 
-  context 'with -o and -g flag' do
+  context 'with -o and -g flag', :use_file_info_stub do
     let(:args) { ['-og', "#{FIXTURES}/a.txt"] }
-
-    before do
-      file_info = instance_double(
-        ColorLS::FileInfo,
-        group: 'sys',
-        mtime: Time.now,
-        directory?: false,
-        owner: 'user',
-        name: 'a.txt',
-        show: 'a.txt',
-        nlink: 1,
-        size: 128,
-        blockdev?: false,
-        chardev?: false,
-        socket?: false,
-        symlink?: false,
-        stats: instance_double(File::Stat,
-                               mode: 0o444, # read for user, owner, other
-                               setuid?: true,
-                               setgid?: true,
-                               sticky?: true),
-        executable?: false
-      )
-
-      allow(ColorLS::FileInfo).to receive(:new).with(
-        path: File.join(FIXTURES, 'a.txt'),
-        parent: FIXTURES,
-        name: 'a.txt',
-        link_info: true,
-        show_filepath: true
-      ) { file_info }
-    end
 
     it 'lists without group info' do
       expect { subject }.not_to output(/sys/).to_stdout
@@ -531,40 +412,8 @@ RSpec.describe ColorLS::Flags do
     end
   end
 
-  context 'with -G flag in a listing format' do
+  context 'with -G flag in a listing format', :use_file_info_stub do
     let(:args) { ['-l', '-G', "#{FIXTURES}/a.txt"] }
-
-    before do
-      file_info = instance_double(
-        ColorLS::FileInfo,
-        group: 'sys',
-        mtime: Time.now,
-        directory?: false,
-        owner: 'user',
-        name: 'a.txt',
-        show: 'a.txt',
-        nlink: 1,
-        size: 128,
-        blockdev?: false,
-        chardev?: false,
-        socket?: false,
-        symlink?: false,
-        stats: instance_double(File::Stat,
-                               mode: 0o444, # read for user, owner, other
-                               setuid?: true,
-                               setgid?: true,
-                               sticky?: true),
-        executable?: false
-      )
-
-      allow(ColorLS::FileInfo).to receive(:new).with(
-        path: File.join(FIXTURES, 'a.txt'),
-        parent: FIXTURES,
-        name: 'a.txt',
-        link_info: true,
-        show_filepath: true
-      ) { file_info }
-    end
 
     it 'lists without group info' do
       expect { subject }.not_to output(/sys/).to_stdout
@@ -589,39 +438,11 @@ RSpec.describe ColorLS::Flags do
     it { expect { subject }.to output(/#{mtime.strftime("%y-%m-%d %k:%M")}/).to_stdout }
   end
 
-  context 'with --no-hardlinks flag in a listing format' do
+  context 'with --no-hardlinks flag in a listing format', :use_file_info_stub do
     let(:args) { ['-l', '--no-hardlink', "#{FIXTURES}/a.txt"] }
 
     before do
-      file_info = instance_double(
-        ColorLS::FileInfo,
-        group: 'sys',
-        mtime: Time.now,
-        directory?: false,
-        owner: 'user',
-        name: 'a.txt',
-        show: 'a.txt',
-        nlink: 987,
-        size: 128,
-        blockdev?: false,
-        chardev?: false,
-        socket?: false,
-        symlink?: false,
-        stats: instance_double(File::Stat,
-                               mode: 0o444, # read for user, owner, other
-                               setuid?: true,
-                               setgid?: true,
-                               sticky?: true),
-        executable?: false
-      )
-
-      allow(ColorLS::FileInfo).to receive(:new).with(
-        path: File.join(FIXTURES, 'a.txt'),
-        parent: FIXTURES,
-        name: 'a.txt',
-        link_info: true,
-        show_filepath: true
-      ) { file_info }
+      allow(a_txt_file_info).to receive(:nlink).and_return 987
     end
 
     it 'lists without hard links count' do


### PR DESCRIPTION
### Description

In order to demonstrate what this PR does, I am displaying the difference in the output of the command `colorls exe/colorls` (which is a file) before and after this PR

#### Before this PR
<img width="197" alt="image" src="https://user-images.githubusercontent.com/19269206/235308993-7bec05de-de5f-43d4-b379-889a5130208e.png">

#### After this PR
<img width="206" alt="image" src="https://user-images.githubusercontent.com/19269206/235309014-a62f475d-947d-4fa6-966d-d211ab3aeae5.png">

#### Comment
This PR takes this gem one step closer to the behaviour of the in-built `ls` command.

### Details

- Relevant Issues : #524 
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [x] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
