### PR TITLE
Colorise hidden files and directories

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -407,6 +407,7 @@ module ColorLS
                   when file.blockdev?   then :blockdev
                   when file.socket?     then :socket
                   when file.executable? then :executable_file
+                  when file.hidden?     then :hidden
                   when @files.key?(key) then :recognized_file
                   else                       :unrecognized_file
                   end
@@ -418,7 +419,7 @@ module ColorLS
         key = content.name.downcase.to_sym
         key = @folder_aliases[key] unless @folders.key? key
         key = :folder if key.nil?
-        color = @colors[:dir]
+        color = content.hidden? ? @colors[:hidden_dir] : @colors[:dir]
         group = :folders
       else
         key = File.extname(content.name).delete_prefix('.').downcase.to_sym

--- a/lib/colorls/fileinfo.rb
+++ b/lib/colorls/fileinfo.rb
@@ -40,6 +40,10 @@ module ColorLS
       @dead
     end
 
+    def hidden?
+      @name.start_with?('.')
+    end
+
     def owner
       return @@users[@stats.uid] if @@users.key? @stats.uid
 

--- a/lib/yaml/dark_colors.yaml
+++ b/lib/yaml/dark_colors.yaml
@@ -9,9 +9,9 @@ dead_link: red
 link:      cyan
 
 # special files
-socket:    green
-blockdev:  green
-chardev:   green
+socket:     green
+blockdev:   green
+chardev:    green
 
 # Access Modes
 write:     darkkhaki

--- a/lib/yaml/dark_colors.yaml
+++ b/lib/yaml/dark_colors.yaml
@@ -12,6 +12,8 @@ link:      cyan
 socket:     green
 blockdev:   green
 chardev:    green
+hidden:     burlywood
+hidden_dir: slategray
 
 # Access Modes
 write:     darkkhaki

--- a/lib/yaml/light_colors.yaml
+++ b/lib/yaml/light_colors.yaml
@@ -12,6 +12,8 @@ link:      cyan
 socket:     darkgray
 blockdev:   darkgray
 chardev:    darkgray
+hidden:     seagreen
+hidden_dir: royalblue
 
 # Access Modes
 write:     red

--- a/lib/yaml/light_colors.yaml
+++ b/lib/yaml/light_colors.yaml
@@ -9,9 +9,9 @@ dead_link: red
 link:      cyan
 
 # special files
-socket:    darkgray
-blockdev:  darkgray
-chardev:   darkgray
+socket:     darkgray
+blockdev:   darkgray
+chardev:    darkgray
 
 # Access Modes
 write:     red


### PR DESCRIPTION
### Description

This PR introduces to keys to `light_colors.yaml` and `dark_colors.yaml` to maintain special colors for hidden files and directories

- Relevant Issues : #546 
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
