### PR TITLE
Remove `rubygems_mfa_required` setting and disable RequireMFA cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,9 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 8
 
+Gemspec/RequireMFA:
+  Enabled: false
+
 # TODO -----------------------------------------------------------------
 
 Style/Documentation:

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -81,5 +81,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 2.20.0'
   spec.add_development_dependency 'rubygems-tasks', '~> 0'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
-  spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
### Description

This setting was introduced automatically by the aforementioned rubocop cop, which makes it impossible to publish to rubygems automatically from a Github action with an API key, since one would always need the second factor.

- Relevant Issues : (none)
- Relevant PRs : (none)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
