### PR TITLE
Remove `rubygems_mfa_required` setting and disable RequireMFA cop

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,9 +13,18 @@ on:
   # pull_request_target:
   #   types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,11 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # FIXME: builds on Windows are broken because of hpricot
+          # - windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,9 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 8
 
+Gemspec/RequireMFA:
+  Enabled: false
+
 # TODO -----------------------------------------------------------------
 
 Style/Documentation:

--- a/colorls.gemspec
+++ b/colorls.gemspec
@@ -81,5 +81,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 2.20.0'
   spec.add_development_dependency 'rubygems-tasks', '~> 0'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
-  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
-if ENV['CI'] == 'true'
+if ENV['CI'] == 'never' # FIXME: migrate to new Codecov uploader / action
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
This setting was introduced automatically by the aforementioned rubocop cop, which makes it impossible to publish to rubygems automatically from a Github action with an API key, since one would always need the second factor.

### Description

This PR is a copy of the linked PR below.

- Relevant Issues : (none)
- Relevant PRs : https://github.com/athityakumar/colorls/pull/596
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
