### PR TITLE
feat(flags): add -F (classify) and -R (recursive) flags

### DIFF
--- a/lib/colorls/core.rb
+++ b/lib/colorls/core.rb
@@ -27,10 +27,11 @@ module ColorLS
   class Core # rubocop:disable Metrics/ClassLength
     MIN_SIZE_CHARS = 4
 
+    # rubocop:disable Metrics/MethodLength
     def initialize(all: false, sort: false, show: false,
       mode: nil, show_git: false, almost_all: false, colors: [], group: nil,
       reverse: false, hyperlink: false, tree_depth: nil, show_inode: false,
-      indicator_style: 'slash', long_style_options: {}, icons: true)
+      indicator_style: 'slash', long_style_options: {}, icons: true, recursive: false)
       @count = {folders: 0, recognized_files: 0, unrecognized_files: 0}
       @all          = all
       @almost_all   = almost_all
@@ -49,15 +50,18 @@ module ColorLS
       @indicator_style = indicator_style
       @hard_links_count = long_style_options.key?(:hard_links_count) ? long_style_options[:hard_links_count] : true
       @icons = icons
+      @recursive = recursive
 
       init_colors colors
       init_icons
     end
+    # rubocop:enable Metrics/MethodLength
 
     def additional_chars_per_item
       12 + (@show_git ? 4 : 0) + (@show_inode ? 10 : 0)
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def ls_dir(info)
       if @tree[:mode]
         print "\n"
@@ -77,7 +81,18 @@ module ColorLS
       return print "\n   Nothing to show here\n".colorize(@colors[:empty]) if @contents.empty?
 
       ls
+
+      return unless @recursive
+
+      @contents.each do |content|
+        next unless content.directory?
+        next if content.name == '.' || content.name == '..'
+
+        puts "\n#{content.path}:"
+        ls_dir(content)
+      end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def ls_files(files)
       @contents = files
@@ -379,7 +394,7 @@ module ColorLS
       value = increment == :folders ? @folders[key] : @files[key]
       logo  = value.gsub(/\\u[\da-f]{4}/i) { |m| [m[-4..].to_i(16)].pack('U') }
       name = @hyperlink ? make_link(content) : content.show
-      name += content.directory? && @indicator_style != 'none' ? '/' : ' '
+      name += get_indicator(content)
       entry = @icons ? "#{out_encode(logo)}  #{out_encode(name)}" : out_encode(name).to_s
       entry = entry.bright if !content.directory? && content.executable?
 
@@ -484,5 +499,23 @@ module ColorLS
       uri = Addressable::URI.convert_path(File.absolute_path(content.path))
       "\033]8;;#{uri}\007#{content.show}\033]8;;\007"
     end
+
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def get_indicator(content)
+      return '' if @indicator_style == 'none'
+
+      if @indicator_style == :classify
+        return '/' if content.directory?
+        return '@' if content.symlink?
+        return '*' if content.executable?
+        return '|' if content.stats.pipe?
+        return '=' if content.stats.socket?
+
+        return ' '
+      end
+
+      content.directory? ? '/' : ' '
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   end
 end

--- a/lib/colorls/fileinfo.rb
+++ b/lib/colorls/fileinfo.rb
@@ -72,7 +72,7 @@ module ColorLS
     end
 
     def_delegators :@stats, :directory?, :socket?, :chardev?, :symlink?, :blockdev?, :mtime, :nlink, :size, :owned?,
-                   :executable?
+                   :executable?, :pipe?
 
     private
 

--- a/lib/colorls/flags.rb
+++ b/lib/colorls/flags.rb
@@ -108,6 +108,7 @@ module ColorLS
         tree_depth: 3,
         show_inode: false,
         indicator_style: 'slash',
+        recursive: false,
         long_style_options: {}
       }
     end
@@ -136,6 +137,7 @@ module ColorLS
       options.on('-r', '--reverse', 'reverse order while sorting') { @opts[:reverse] = true }
     end
 
+    # rubocop:disable Metrics/MethodLength
     def add_common_options(options)
       options.on('-a', '--all', 'do not ignore entries starting with .')  { @opts[:all] = true }
       options.on('-A', '--almost-all', 'do not list . and ..')            { @opts[:almost_all] = true }
@@ -143,6 +145,10 @@ module ColorLS
       options.on('-f', '--files', 'show only files')                      { @opts[:show] = :files }
       options.on('--gs', '--git-status', 'show git status for each file') { @opts[:show_git] = true }
       options.on('-p', 'append / indicator to directories')               { @opts[:indicator_style] = 'slash' }
+      options.on('-F', '--classify', 'append indicator (one of */=>@|) to entries') do
+        @opts[:indicator_style] = :classify
+      end
+      options.on('-R', '--recursive', 'list subdirectories recursively')  { @opts[:recursive] = true }
       options.on('-i', '--inode', 'show inode number')                    { @opts[:show_inode] = true }
       options.on('--report=[WORD]', %w[short long], 'show report: short, long (default if omitted)') do |word|
         word ||= :long
@@ -150,11 +156,13 @@ module ColorLS
       end
       options.on(
         '--indicator-style=[STYLE]',
-        %w[none slash], 'append indicator with style STYLE to entry names: none, slash (-p) (default)'
+        %w[none slash classify],
+        'append indicator with style STYLE to entry names: none, slash (-p) (default), classify (-F)'
       ) do |style|
         @opts[:indicator_style] = style
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def add_format_options(options)
       options.on(

--- a/spec/color_ls/flags_spec.rb
+++ b/spec/color_ls/flags_spec.rb
@@ -504,4 +504,52 @@ RSpec.describe ColorLS::Flags do
       expect { subject }.to output(/#{args.first}/).to_stdout
     end
   end
+
+  context 'with -F/--classify flag' do
+    let(:args) { ['-F', '-1', FIXTURES] }
+
+    it 'appends / to directories' do
+      expect { subject }.to output(/symlinks\//).to_stdout
+    end
+  end
+
+  context 'with -F flag on symlinks directory' do
+    let(:args) { ['-F', '-1', File.join(FIXTURES, 'symlinks')] }
+
+    it 'appends @ to symlinks' do
+      expect { subject }.to output(/ReadmeLink.md@/).to_stdout
+    end
+  end
+
+  context 'with --indicator-style=classify' do
+    let(:args) { ['--indicator-style=classify', '-1', FIXTURES] }
+
+    it 'appends / to directories' do
+      expect { subject }.to output(/symlinks\//).to_stdout
+    end
+  end
+
+  context 'with -R/--recursive flag' do
+    let(:args) { ['-R', FIXTURES] }
+
+    it 'lists subdirectories recursively' do
+      expect { subject }.to output(/second-level:/).to_stdout
+    end
+
+    it 'lists files in subdirectories' do
+      expect { subject }.to output(/third-level-file.txt/).to_stdout
+    end
+  end
+
+  context 'with -FR flags combined' do
+    let(:args) { ['-FR', '-1', FIXTURES] }
+
+    it 'applies both classify and recursive' do
+      expect { subject }.to output(/symlinks\//).to_stdout
+    end
+
+    it 'shows recursive content' do
+      expect { subject }.to output(/third-level-file.txt/).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
Introduces two new flags to improve compatibility with the standard  command:  for classifying files and  for recursive listing.

- The  or  flag appends an indicator (*/=>@|) to entries to signify the file type.
- The  or  flag lists subdirectories recursively.

These changes provide more -like functionality to , making it a more powerful and familiar tool for users.

### Description

This PR adds -F (--classify) and -R (--recursive) flags to improve ls compatibility, allowing file type indicators and recursive listing respectively, making colorls more powerful and familiar.

- Relevant Issues : #103
- Relevant PRs : (none)
- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
